### PR TITLE
Move WebRTC.isSupported property to mediaHandlerFactory method.

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -1531,11 +1531,12 @@ InviteClientContext = function(ua, target, options) {
   var requestParams, iceServers,
     extraHeaders = options.extraHeaders || [],
     stunServers = options.stunServers || null,
-    turnServers = options.turnServers || null;
+    turnServers = options.turnServers || null,
+    isMediaSupported = ua.configuration.mediaHandlerFactory.isSupported;
 
   // Check WebRTC support
-  if (!SIP.WebRTC.isSupported) {
-    throw new SIP.Exceptions.NotSupportedError('WebRTC not supported');
+  if (isMediaSupported && !isMediaSupported()) {
+    throw new SIP.Exceptions.NotSupportedError('Media not supported');
   }
 
   this.RTCConstraints = options.RTCConstraints || {};

--- a/src/UA.js
+++ b/src/UA.js
@@ -662,7 +662,8 @@ UA.prototype.receiveRequest = function(request) {
   if(!request.to_tag) {
     switch(method) {
       case SIP.C.INVITE:
-        if(SIP.WebRTC.isSupported) {
+        var isMediaSupported = this.configuration.mediaHandlerFactory.isSupported;
+        if(!isMediaSupported || isMediaSupported()) {
           session = new SIP.InviteServerContext(this, request)
             .on('invite', function() {
               self.emit('invite', this);

--- a/src/WebRTC.js
+++ b/src/WebRTC.js
@@ -11,18 +11,27 @@ WebRTC.MediaHandler = @@include('../src/WebRTC/MediaHandler.js')
 
 WebRTC.MediaStreamManager = @@include('../src/WebRTC/MediaStreamManager.js')
 
-WebRTC.MediaStream = SIP.Utils.getPrefixedProperty(window, 'MediaStream');
-WebRTC.getUserMedia = SIP.Utils.getPrefixedProperty(window.navigator, 'getUserMedia');
-WebRTC.RTCPeerConnection = SIP.Utils.getPrefixedProperty(window, 'RTCPeerConnection');
-WebRTC.RTCSessionDescription = SIP.Utils.getPrefixedProperty(window, 'RTCSessionDescription');
+var _isSupported;
 
-if (WebRTC.getUserMedia && WebRTC.RTCPeerConnection && WebRTC.RTCSessionDescription) {
-  WebRTC.getUserMedia = WebRTC.getUserMedia.bind(window.navigator);
-  WebRTC.isSupported = true;
-}
-else {
-  WebRTC.isSupported = false;
-}
+WebRTC.isSupported = function () {
+  if (_isSupported !== undefined) {
+    return _isSupported;
+  }
+
+  WebRTC.MediaStream = SIP.Utils.getPrefixedProperty(window, 'MediaStream');
+  WebRTC.getUserMedia = SIP.Utils.getPrefixedProperty(window.navigator, 'getUserMedia');
+  WebRTC.RTCPeerConnection = SIP.Utils.getPrefixedProperty(window, 'RTCPeerConnection');
+  WebRTC.RTCSessionDescription = SIP.Utils.getPrefixedProperty(window, 'RTCSessionDescription');
+
+  if (WebRTC.getUserMedia && WebRTC.RTCPeerConnection && WebRTC.RTCSessionDescription) {
+    WebRTC.getUserMedia = WebRTC.getUserMedia.bind(window.navigator);
+    _isSupported = true;
+  }
+  else {
+    _isSupported = false;
+  }
+  return _isSupported;
+};
 
 SIP.WebRTC = WebRTC;
 }(SIP));

--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -110,6 +110,9 @@ var MediaHandler = function(session, options) {
 MediaHandler.defaultFactory = function defaultFactory (session, options) {
   return new MediaHandler(session, options);
 };
+MediaHandler.defaultFactory.isSupported = function () {
+  return SIP.WebRTC.isSupported();
+};
 
 MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
 // Functions the session can use

--- a/src/WebRTC/MediaStreamManager.js
+++ b/src/WebRTC/MediaStreamManager.js
@@ -10,6 +10,10 @@
 
 // Default MediaStreamManager provides single-use streams created with getUserMedia
 var MediaStreamManager = function MediaStreamManager (defaultConstraints) {
+  if (!SIP.WebRTC.isSupported()) {
+    throw new SIP.Exceptions.NotSupportedError('Media not supported');
+  }
+
   var events = [
   ];
   this.setConstraints(defaultConstraints);

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -1540,11 +1540,11 @@ describe('InviteClientContext', function() {
   });
 
   it('throws a not supported error if WebRTC is not supported', function() {
-    SIP.WebRTC.isSupported = false;
+    spyOn(SIP.WebRTC, 'isSupported').andCallFake(function () {
+      return false;
+    });
 
-    expect(function() {new SIP.InviteClientContext(ua, target);}).toThrow('WebRTC not supported');
-
-    SIP.WebRTC.isSupported = true;
+    expect(function() {new SIP.InviteClientContext(ua, target);}).toThrow('Media not supported');
   });
 
   it('throws a type error if normalizeTarget fails with the given target', function() {

--- a/test/spec/SpecUA.js
+++ b/test/spec/SpecUA.js
@@ -744,12 +744,12 @@ describe('UA', function() {
                       ruri : { user: UA.configuration.uri.user } ,
                       reply : replySpy };
       var webrtc = SIP.WebRTC.isSupported;
-      SIP.WebRTC.isSupported = false;
+      spyOn(SIP.WebRTC, 'isSupported').andCallFake(function () {
+        return false;
+      });
 
       UA.receiveRequest(request);
       expect(replySpy).toHaveBeenCalledWith(488);
-
-      SIP.WebRTC.isSupported = webrtc;
     });
 
     it('sends a 481 if a BYE is received', function() {


### PR DESCRIPTION
Instead of checking SIP.WebRTC.isSupported, SIP.js checks
mediaHandlerFactory.isSupported(). If the method is not defined, it is
considered to have returned true, making it optional for a custom
mediaHandlerFactory.

This has the side effect of binding SIP.WebRTC constructor methods only after
SIP.WebRTC.isSupported is called.

fixes #37
