### PR TITLE
WebRTC.MediaHandler: peerConnection.onaddstream emits 'addStream' event

### DIFF
--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -22,7 +22,8 @@ var MediaHandler = function(session, options) {
     'iceFailed',
     'getDescription',
     'setDescription',
-    'dataChannel'
+    'dataChannel',
+    'addStream'
   ];
   options = options || {};
 
@@ -71,6 +72,7 @@ var MediaHandler = function(session, options) {
   this.peerConnection.onaddstream = function(e) {
     self.logger.log('stream added: '+ e.stream.id);
     self.render();
+    self.emit('addStream', e);
   };
 
   this.peerConnection.onremovestream = function(e) {


### PR DESCRIPTION
See https://github.com/onsip/SIP.js/issues/23#issuecomment-46866780

I made it `addStream` instead of `streamAdded` to make it more consistent with the peer connection and the other events.
