### PR TITLE
src/Session.js: Replace 'referred' event with 'refer' handler helper

### DIFF
--- a/test/spec/Session.js
+++ b/test/spec/Session.js
@@ -60,7 +60,6 @@ describe('An INVITE sent from a UAC', function () {
     runs(function () {
       expect(session.checkEvent('connecting')).toBe(true);
       expect(session.checkEvent('cancel')).toBe(true);
-      expect(session.checkEvent('referred')).toBe(true);
       expect(session.checkEvent('dtmf')).toBe(true);
       expect(session.checkEvent('bye')).toBe(true);
     });

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -27,7 +27,6 @@ describe('Session', function() {
     expect(Session.checkEvent('dtmf')).toBeTruthy();
     expect(Session.checkEvent('invite')).toBeTruthy();
     expect(Session.checkEvent('cancel')).toBeTruthy();
-    expect(Session.checkEvent('referred')).toBeTruthy();
     expect(Session.checkEvent('bye')).toBeTruthy();
     expect(Session.checkEvent('hold')).toBeTruthy();
     expect(Session.checkEvent('unhold')).toBeTruthy();
@@ -852,18 +851,6 @@ describe('Session', function() {
     });
   });
 
-  describe('.referred', function() {
-    beforeEach(function() {
-      spyOn(Session, 'emit').andCallThrough();
-    });
-
-    it('emits and returns Session', function() {
-      expect(Session.referred()).toBe(Session);
-
-      expect(Session.emit.calls[0].args[0]).toBe('referred');
-    });
-  });
-
   describe('.canceled', function() {
     beforeEach(function() {
       spyOn(Session, 'close');
@@ -1490,23 +1477,23 @@ describe('InviteServerContext', function() {
     });
 
     describe('method is REFER', function() {
-      it('replies 202, then calls referred and terminate if there is a referred listener', function() {
+      it('replies 202, then calls callback and terminate if there is a session.followRefer listener', function() {
         InviteServerContext.status = 12;
         req = SIP.Parser.parseMessage('REFER sip:gled5gsn@hk95bautgaa7.invalid;transport=ws;aor=james%40onsnip.onsip.com SIP/2.0\r\nMax-Forwards: 65\r\nTo: <sip:james@onsnip.onsip.com>\r\nrefer-to: <sip:charles@example.com>\r\nFrom: "test1" <sip:test1@onsnip.onsip.com>;tag=rto5ib4052\r\nCall-ID: grj0liun879lfj35evfq\r\nCSeq: 1798 INVITE\r\nContact: <sip:e55r35u3@kgu78r4e1e6j.invalid;transport=ws;ob>\r\nAllow: ACK,CANCEL,BYE,OPTIONS,INVITE,MESSAGE\r\nContent-Type: application/json\r\nSupported: outbound\r\nUser-Agent: SIP.js 0.5.0-devel\r\nContent-Length: 11\r\n\r\na=sendrecv\r\n', InviteServerContext.ua);
 
         spyOn(req, 'reply');
-        spyOn(InviteServerContext, 'referred');
+        var referFollowed = jasmine.createSpy('referFollowed');
         spyOn(InviteServerContext, 'terminate');
         InviteServerContext.dialog = new SIP.Dialog(InviteServerContext, InviteServerContext.request, 'UAS');
         spyOn(InviteServerContext.dialog, 'sendRequest');
-        InviteServerContext.on('referred', function(){});
+        InviteServerContext.on('refer', InviteServerContext.followRefer(referFollowed));
 
         InviteServerContext.receiveRequest(req);
 
         //More can be tested here... another Session/* problem
 
         expect(req.reply).toHaveBeenCalledWith(202, 'Accepted');
-        expect(InviteServerContext.referred).toHaveBeenCalled();
+        expect(referFollowed).toHaveBeenCalled();
         expect(InviteServerContext.terminate).toHaveBeenCalled();
       });
     });
@@ -2128,7 +2115,7 @@ describe('InviteClientContext', function() {
       //can't check much here, Session/* problem
     });
 
-    it('logs, replies 202, then calls referred and terminate if referred listener present', function() {
+    it('logs, replies 202, then calls callback and terminate if session.followRefer listener present', function() {
       InviteClientContext.status = 12;
       request.method = SIP.C.REFER;
       request.parseHeader = jasmine.createSpy('parseHeader').andReturn({uri: 'uri'});
@@ -2136,11 +2123,11 @@ describe('InviteClientContext', function() {
 /*       spyOn(InviteClientContext.dialog.sendRequest); */
 
       spyOn(InviteClientContext.logger, 'log');
-      spyOn(InviteClientContext, 'referred');
+      var referFollowed = jasmine.createSpy('referFollowed');
       spyOn(InviteClientContext, 'terminate');
       spyOn(InviteClientContext.ua, 'invite');
 
-      InviteClientContext.on('referred', function(){});
+      InviteClientContext.on('refer', InviteClientContext.followRefer(referFollowed));
 
       InviteClientContext.receiveRequest(request);
       //no way to avoid request.send
@@ -2149,7 +2136,7 @@ describe('InviteClientContext', function() {
       expect(request.reply).toHaveBeenCalledWith(202, 'Accepted');
 /*       expect(InviteClientContext.dialog.sendRequest).toHaveBeenCalled(); */
       expect(InviteClientContext.ua.invite).toHaveBeenCalled();
-      expect(InviteClientContext.referred).toHaveBeenCalled();
+      expect(referFollowed).toHaveBeenCalled();
       expect(InviteClientContext.terminate).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
fixes #48

To migrate applications, replace:

  session.on('referred', referFollowed);

with:

  session.on('refer', session.followRefer(referFollowed));
