### PR TITLE
Session: on re-INVITE, send 488 instead of calling this.receiveReinvite

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -622,7 +622,9 @@ Session.prototype = {
       case SIP.C.INVITE:
         if(this.status === C.STATUS_CONFIRMED) {
           this.logger.log('re-INVITE received');
-          this.receiveReinvite(request);
+          // Switch these two lines to try re-INVITEs:
+          //this.receiveReinvite(request);
+          request.reply(488, null, ["Warning: Cannot update media description"]);
         }
         break;
       case SIP.C.INFO:

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -1445,7 +1445,7 @@ describe('InviteServerContext', function() {
     });
 
     describe('method is INVITE', function() {
-      it('calls receiveReinvite', function() {
+      xit('calls receiveReinvite', function() {
         InviteServerContext.status = 12;
         req = SIP.Parser.parseMessage('INVITE sip:gled5gsn@hk95bautgaa7.invalid;transport=ws;aor=james%40onsnip.onsip.com SIP/2.0\r\nMax-Forwards: 65\r\nTo: <sip:james@onsnip.onsip.com>\r\nFrom: "test1" <sip:test1@onsnip.onsip.com>;tag=rto5ib4052\r\nCall-ID: grj0liun879lfj35evfq\r\nCSeq: 1798 INVITE\r\nContact: <sip:e55r35u3@kgu78r4e1e6j.invalid;transport=ws;ob>\r\nAllow: ACK,CANCEL,BYE,OPTIONS,INVITE,MESSAGE\r\nContent-Type: application/json\r\nSupported: outbound\r\nUser-Agent: SIP.js 0.5.0-devel\r\nContent-Length: 11\r\n\r\na=sendrecv\r\n', InviteServerContext.ua);
 
@@ -2095,7 +2095,7 @@ describe('InviteClientContext', function() {
       expect(InviteClientContext.terminated).toHaveBeenCalledWith(request, SIP.C.causes.BYE);
     });
 
-    it('logs and calls receiveReinvite if request method is INVITE', function() {
+    xit('logs and calls receiveReinvite if request method is INVITE', function() {
       InviteClientContext.status = 12;
       request.method = SIP.C.INVITE;
 


### PR DESCRIPTION
See https://github.com/onsip/SIP.js/issues/19#issuecomment-43887857

I tested this against a conference call using Freeswitch 1.5.11 installed as [described on sipjs.com](http://sipjs.com/guides/server-configuration/freeswitch/), received and rejected the re-invites, and was able to remain in the conference for several multiples of the `Session-Expires` header's value afterwards. I didn't receive any more re-invites, so I think rejecting the first one successfully tells Freeswitch we don't currently support session timers.

This also prevents non-timer renegotiation (example: hold), which seems ok since the browsers don't currently have general support for it. See https://github.com/onsip/SIP.js/issues/19#issuecomment-43680028

fixes #19
