### PR TITLE
WebRTC.MediaHandler: don't pass constraints to peerConnection.addStream

### DIFF
--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -207,8 +207,7 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
       self.addStream(
         stream,
         streamAdditionSucceeded,
-        onFailure,
-        self.RTCConstraints
+        onFailure
       );
     }
 
@@ -452,9 +451,9 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
     );
   }},
 
-  addStream: {writable: true, value: function addStream (stream, onSuccess, onFailure, constraints) {
+  addStream: {writable: true, value: function addStream (stream, onSuccess, onFailure) {
     try {
-      this.peerConnection.addStream(stream, constraints);
+      this.peerConnection.addStream(stream);
     } catch(e) {
       this.logger.error('error adding stream');
       this.logger.error(e);


### PR DESCRIPTION
This argument:
- [was removed from the current draft WebRTC spec](http://dev.w3.org/2011/webrtc/editor/archives/20140617/webrtc.html#changes-since-august-30-2013) (no. 16)
- [was optional before it was removed](http://dev.w3.org/2011/webrtc/editor/archives/20130830/webrtc.html#widl-RTCPeerConnection-addStream-void-MediaStream-stream-MediaConstraints-constraints)
- doesn't seem useful to applications

Also, this facilitates compatibility with WebRTC plugins (such as [Temasys's](https://temasys.atlassian.net/wiki/display/TWPP/WebRTC+Plugins))
that cause an error if the argument is passed.
