### PR TITLE
Allows ua.invite with 'media' key in options.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,6 +19,7 @@ You just need to have [Node.js](http://nodejs.org/) and [Git](http://git-scm.com
 
 * [Install PhantomJS](http://phantomjs.org/download.html)
 * In modern Debian/Ubuntu systems PhantomJS can be installed via `apt-get install phantomjs`
+* On OSX with [homebrew](http://brew.sh/) PhantomJS can be installed via `brew install phantomjs`
 
 
 ## How to build SIP.js
@@ -58,7 +59,7 @@ Run `grunt devel` for just generating the `dist/sip-devel.js` file. An uncompres
 
 ## Test units
 
-SIP.js includes test units based on [Jasmine](http://pivotal.github.io/jasmine/). Test units use the `dist/sip-devel.js` file. Run the tests as follows:
+SIP.js includes test units based on [Jasmine](http://pivotal.github.io/jasmine/). Test units use the `dist/sip-devel.js` file. **If you made changes, be sure to run `grunt devel` before running the tests.** Run the tests as follows:
 ```
 $ grunt test
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -71,6 +71,14 @@ Utils= {
     }
   },
 
+  isMediaStream: function(obj) {
+    if (obj !== undefined) {
+      return Object.prototype.toString.call(obj) === '[object MediaStream]';
+    } else {
+      return false;
+    }
+  },
+
   isDecimal: function (num) {
     return !isNaN(num) && (parseFloat(num) === parseInt(num,10));
   },

--- a/src/WebRTC/MediaStreamManager.js
+++ b/src/WebRTC/MediaStreamManager.js
@@ -96,6 +96,8 @@ MediaStreamManager.prototype = Object.create(SIP.EventEmitter.prototype, {
 
     if (mediaHint.stream) {
       saveSuccess(mediaHint.stream, true);
+    } else if (SIP.Utils.isMediaStream(mediaHint)) {
+      saveSuccess(mediaHint, true);
     } else {
       // Fallback to audio/video enabled if no mediaHint can be found.
       var constraints = mediaHint.constraints ||

--- a/test/spec/MediaStreamManager.js
+++ b/test/spec/MediaStreamManager.js
@@ -137,6 +137,16 @@ describe('MediaStreamManager', function() {
       expect(onFailure).not.toHaveBeenCalled();
     });
 
+    it('.acquire when mediaHint is a stream', function() {
+      spyOn(SIP.WebRTC, 'getUserMedia');
+      spyOn(SIP.Utils, 'isMediaStream').andReturn(true);
+
+      mediaStreamManager.acquire(onSuccess, onFailure, stream);
+      expect(SIP.Utils.isMediaStream(stream)).toEqual(true);
+      expect(SIP.WebRTC.getUserMedia).not.toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalledWith(stream);
+    });
+
     it('.release does not stop the stream', function () {
       mediaStreamManager.acquire(onSuccess, onFailure, mediaHint);
       mediaStreamManager.release(stream);


### PR DESCRIPTION
Up until recently we used 0.5.0 and

```
var options = {
    media: mediaStream
  };
ua.invite(target, options);
```

were "mediaStream" is an existing stream. (I believe that comes straight
from the [documentation](http://sipjs.com/guides/reuse-mediastreams/))

Today we switched to master and noticed that we got prompted with
Chrome's "wants you to use camera..." twice. It looks like the invite
now expects different options parameters and does not respond to
`mediaHint.stream`. Therefore we call getUserMedia again.

I wanted to keep it simple and change as little as possible.

While running/writing the tests I ran into some issues
(that I documented in BUILDING.md).
