### PR TITLE
Allow event handlers to be invoked with a variable no. of arguments

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -65,6 +65,7 @@ UA = function(configuration) {
 
   // Helper function for forwarding events
   function selfEmit(type) {
+  	//registrationFailed handler is invoked with two arguments. Allow event handlers to be invoked with a variable no. of arguments
   	return self.emit.bind(self, type);
   }
 


### PR DESCRIPTION
Currently, the registrationFailed handler loses the **cause** argument even if it was passed.
`sip.ua.on('registrationFailed', function(response, cause) {
  //cause is undefined here
});
`
This is because `function selfEmit` passes along only one argument to its handler.

Creating a function that is bound to the `self` object and argument `type`, allows the handler to be invoked with a variable no. of arguments. 
