### PR TITLE
RFC 3261-compliant Warning header

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -638,7 +638,7 @@ Session.prototype = {
           this.logger.log('re-INVITE received');
           // Switch these two lines to try re-INVITEs:
           //this.receiveReinvite(request);
-          request.reply(488, null, ["Warning: Cannot update media description"]);
+          request.reply(488, null, ['Warning: 399 sipjs "Cannot update media description"']);
         }
         break;
       case SIP.C.INFO:


### PR DESCRIPTION
Avoid non-standard headers if possible.

http://tools.ietf.org/html/rfc3261#section-20.43

> <pre>
> The Warning header field is used to carry additional information
> about the status of a response.  Warning header field values are sent
> with responses and contain a three-digit warning code, host name, and
> warning text.<br>
> The "warn-text" should be in a natural language that is most likely
> to be intelligible to the human user receiving the response.
> </pre>

http://tools.ietf.org/html/rfc3261#page-232

> <pre>Warning        =  "Warning" HCOLON warning-value *(COMMA warning-value)
> warning-value  =  warn-code SP warn-agent SP warn-text
> warn-code      =  3DIGIT
> warn-agent     =  hostport / pseudonym
>                   ;  the name or pseudonym of the server adding
>                   ;  the Warning header, for use in debugging
> </pre>

http://tools.ietf.org/html/rfc3261#page-182

> <pre>399 Miscellaneous warning: The warning text can include arbitrary
>     information to be presented to a human user or logged.  A
>     system receiving this warning MUST NOT take any automated
>     action.
> </pre>
