### PR TITLE
Media Handler: renderHint local/remote is an (Array of) HTMLMediaElement

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -67,9 +67,7 @@ Utils= {
             video: options.tagName === 'VIDEO'
           },
           render: {
-            remote: {
-              video: options
-            }
+            remote: options
           }
         }
       };

--- a/src/WebRTC/MediaStreamManager.js
+++ b/src/WebRTC/MediaStreamManager.js
@@ -39,18 +39,28 @@ MediaStreamManager.streamId = function (stream) {
     .join('');
 };
 
+/**
+ * @param {(Array of) MediaStream} streams - The streams to render
+ *
+ * @param {(Array of) HTMLMediaElement} elements
+ *        - The <audio>/<video> element(s) that should render the streams
+ *
+ * Each stream in streams renders to the corresponding element in elements,
+ * wrapping around elements if needed.
+ */
 MediaStreamManager.render = function render (streams, elements) {
-  // only render first stream, see pull request #76
-  streams = [].concat(streams);
-  var stream = streams[0];
-  if (!elements || !stream) {
+  if (!elements) {
     return false;
   }
+  if (Array.isArray(elements) && !elements.length) {
+    throw new TypeError('elements must not be empty');
+  }
 
-  function attachAndPlay (element, stream) {
-    if (typeof element === 'function') {
-      element = element();
+  function attachAndPlay (elements, stream, index) {
+    if (typeof elements === 'function') {
+      elements = elements();
     }
+    var element = elements[index % elements.length];
     (environment.attachMediaStream || attachMediaStream)(element, stream);
     ensureMediaPlaying(element);
   }
@@ -80,15 +90,10 @@ MediaStreamManager.render = function render (streams, elements) {
     }, interval);
   }
 
-  if (elements.video) {
-    if (elements.audio) {
-      elements.video.volume = 0;
-    }
-    attachAndPlay(elements.video, stream);
-  }
-  if (elements.audio) {
-    attachAndPlay(elements.audio, stream);
-  }
+  // [].concat "casts" `elements` into an array
+  // so forEach works even if `elements` was a single element
+  elements = [].concat(elements);
+  [].concat(streams).forEach(attachAndPlay.bind(null, elements));
 };
 
 MediaStreamManager.prototype = Object.create(SIP.EventEmitter.prototype, {


### PR DESCRIPTION
This removes one layer of nesting from the `invite`/`accept` `mediaHint`.

Note that `<video>` elements no longer get muted if an `<audio>` is provided alongside.

Usage (compare with 4096365):

```javascript
  var session = new SIP.UA().invite('welcome@onsip.com', {
    media: {
      render: {
        remote: [
          document.createElement('audio'), // included to demo array support
          document.createElement('video')
        ],
        local: document.createElement('video')
      }
    }
  });
```