### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sip.js",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "authors": [
     "Will Mitchell <will@onsip.com>",
     "James Criscuolo <james@onsip.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sip.js",
   "title": "SIP.js",
   "description": "A simple, intuitive, and powerful JavaScript signaling library",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "src/SIP.js",
   "homepage": "http://sipjs.com",
   "author": "Will Mitchell <will@onsip.com>",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.sipjs" version="0.6.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.sipjs" version="0.6.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>sip.js</name>
     <!--
       Using src/SIP.js has issues with require('../package.json')


### PR DESCRIPTION
I added Cordova plugin support in dc0549d8d300a27b42ca889cd49f33d2bbf54c91, but it's only useful if it is released, since it currently requires `dist/sip.js` to be used. This PR simply bumps the version numbers in `package.json`, `bower.json`, and `plugin.xml`. I'll create another PR for with the `dist/` files for the actual release.
