### PR TITLE
Allow outgoing Subscriptions that expire in under 3600 seconds

### DIFF
--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -26,9 +26,7 @@ SIP.Subscription = function (ua, target, event, options) {
     this.event = event;
   }
 
-  if (!options.expires || options.expires < 3600) {
-    this.expires = 3600; //1 hour (this is minimum by RFC 6665)
-  } else if(typeof options.expires !== 'number'){
+  if(typeof options.expires !== 'number'){
     ua.logger.warn('expires must be a number. Using default of 3600.');
     this.expires = 3600;
   } else {
@@ -193,7 +191,7 @@ SIP.Subscription.prototype = {
     function setExpiresTimeout() {
       if (sub_state.expires) {
         sub_state.expires = Math.min(sub.expires,
-                                     Math.max(sub_state.expires, 3600));
+                                     Math.max(sub_state.expires, 0));
         sub.timers.sub_duration = SIP.Timers.setTimeout(sub.subscribe.bind(sub),
                                                     sub_state.expires * 1000);
       }

--- a/test/spec/SpecSubscription.js
+++ b/test/spec/SpecSubscription.js
@@ -26,17 +26,19 @@ describe('Subscription', function() {
       expect(function() {new SIP.Subscription(ua, 'alice@example.com');}).toThrowError('Event necessary to create a subscription.');
     });
 
-    it('sets expires to default if nothing is passed, a number < 3600 is passed, or a non-number is passed', function() {
+    it('sets expires to 3600 if nothing is passed, or a non-number is passed', function() {
       Subscription = new SIP.Subscription(ua, 'alice@example.com', 'dialog');
-      expect(Subscription.expires).toBe(3600);
-
-      Subscription = new SIP.Subscription(ua, 'alice@example.com', 'dialog', {expires: 1000});
       expect(Subscription.expires).toBe(3600);
 
       spyOn(ua.logger, 'warn');
       Subscription = new SIP.Subscription(ua, 'alice@example.com', 'dialog', {expires: 'nope'});
       expect(Subscription.expires).toBe(3600);
       expect(ua.logger.warn).toHaveBeenCalledWith('expires must be a number. Using default of 3600.');
+    });
+
+    it('allows expires less than 3600', function() {
+      Subscription = new SIP.Subscription(ua, 'alice@example.com', 'dialog', {expires: 1000});
+      expect(Subscription.expires).toBe(1000);
     });
 
     it('sets expires to a valid number passed in', function() {
@@ -401,13 +403,13 @@ describe('Subscription', function() {
       expect(Subscription.timers.sub_duration).toBeDefined();
     });
 
-    it('expires is reset correctly if too low', function() {
+    it('expires is not reset if under 3600', function() {
       request.setHeader('Subscription-State', 'active;expires=700');
       spyOn(SIP.Timers, 'setTimeout').and.callThrough();
 
       Subscription.receiveRequest(request);
 
-      expect(SIP.Timers.setTimeout.calls.argsFor(0)[1]).toBe(3600000);
+      expect(SIP.Timers.setTimeout.calls.argsFor(0)[1]).toBe(700000);
       expect(Subscription.timers.sub_duration).not.toBeNull();
       expect(Subscription.timers.sub_duration).toBeDefined();
     });


### PR DESCRIPTION
(not just pushing since I heard @wakamoleguy feels strongly about this)

This addresses: https://groups.google.com/forum/#!msg/sip_js/TshLqnjmjKY/uMXb6aihu3oJ

Note that RFC 6665 does not require subscriptions to last an hour, it merely
allows notifiers to reject subscriptions that are shorter: http://tools.ietf.org/html/rfc6665#page-18
