### PR TITLE
Update src/WebRTC/MediaHandler.js - Fix Chrome HOLD.

### DIFF
--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -415,7 +415,7 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
     }
 
     function onSetLocalDescriptionSuccess() {
-      if (self.peerConnection.iceGatheringState === 'complete' && self.peerConnection.iceConnectionState === 'connected') {
+      if (self.peerConnection.iceGatheringState === 'complete' && (self.peerConnection.iceConnectionState === 'connected' || self.peerConnection.iceConnectionState === 'completed')) {
         readySuccess();
       } else {
         self.onIceCompleted = function(pc) {


### PR DESCRIPTION
Fix the chrome hold by allowing it to fire the readySuccess() when connection state is completed, not connected (guessing this is a Chrome assignment issue?)

When i call session.hold() in Chrome, i've found that self.peerConnection.iceConnectionState is set to completed instead of connected, this is not the case in Firefox, i think this little patch should do the job as i don't have any issues in Chrome 37.0.2062.76 beta-m, Chrome Canary 38.0.2125.0 canary (64-bit) or Firefox 31.0.

There's probably a more elegant solution to this, but for now this should work.
