### PR TITLE
Allow '0' as a DTMF tone.

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -134,7 +134,7 @@ Session.prototype = {
     }
 
     // Check tones
-    if (tones === false || (typeof tones !== 'string' && typeof tones !== 'number') || !tones.toString().match(/^[0-9A-D#*,]+$/i)) {
+    if ((typeof tones !== 'string' && typeof tones !== 'number') || !tones.toString().match(/^[0-9A-D#*,]+$/i)) {
       throw new TypeError('Invalid tones: '+ tones);
     }
 


### PR DESCRIPTION
Checking for !tones fails when the DTMF tone is 0 or '0', so check with ===false instead. The typeof checks will still catch undefined and nulls.
