### PR TITLE
Add npm-shrinkwrap.json with jasmine-core@2.0.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1639,9 +1639,9 @@
           "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.0.3.tgz"
         },
         "jasmine-core": {
-          "version": "2.1.2",
+          "version": "2.0.4",
           "from": "jasmine-core@>=2.0.4",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.0.4.tgz"
         }
       }
     },


### PR DESCRIPTION
This prevents Travis builds from breaking due to jasmine-core@2.1.2. Once the underlying problems in grunt-contrib-jasmine/jasmine-core are solved, we should remove npm-shrinkwrap.json.
