### PR TITLE
Emit created Dialogs from their owners

### DIFF
--- a/src/Dialogs.js
+++ b/src/Dialogs.js
@@ -91,6 +91,7 @@ Dialog = function(owner, message, type, state) {
   this.owner = owner;
   owner.ua.dialogs[this.id.toString()] = this;
   this.logger.log('new ' + type + ' dialog created with status ' + (this.state === C.STATUS_EARLY ? 'EARLY': 'CONFIRMED'));
+  owner.initMoreEvents(['dialog']);
   owner.emit('dialog', this);
 };
 

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -1125,14 +1125,14 @@ describe('InviteServerContext', function() {
 
     jasmine.clock().tick(100);
 
-    expect(ISC.emit.calls.argsFor(1)[0]).toBe('progress');
+    expect(ISC.emit.calls.argsFor(2)[0]).toBe('progress');
 
     expect(ISC.status).toBe(4);
 
     expect(ISC.timers.userNoAnswerTimer).toBeDefined();
     expect(ISC.timers.expiresTimer).toBeDefined();
 
-    expect(ISC.emit.calls.argsFor(2)[0]).toBe('invite');
+    expect(ISC.emit.calls.argsFor(3)[0]).toBe('invite');
 
     jasmine.clock().uninstall();
   });


### PR DESCRIPTION
This allows the application to learn when dialogs are created and respond accordingly. For example: a caller could send in-dialog MESSAGE requests to potential callees before the call is answered.
