### PR TITLE
Invite options

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "grunt travis --verbose"
   },
   "dependencies": {
+    "extend": "^2.0.0",
     "pegjs": "0.8.0",
     "ws": "^0.6.4"
   },

--- a/src/Session.js
+++ b/src/Session.js
@@ -1,6 +1,7 @@
 module.exports = function (SIP, environment) {
 
 var DTMF = require('./Session/DTMF')(SIP);
+var extend = require('extend');
 
 var Session, InviteServerContext, InviteClientContext,
  C = {
@@ -1001,6 +1002,8 @@ InviteServerContext = function(ua, request) {
 
   this.logger = ua.getLogger('sip.inviteservercontext', this.id);
 
+  this.extend = extend;
+
   //Save the session into the ua sessions collection.
   this.ua.sessions[this.id] = this;
 
@@ -1270,7 +1273,7 @@ InviteServerContext.prototype = {
    * @param {Object} [options.media] gets passed to SIP.MediaHandler.getDescription as mediaHint
    */
   accept: function(options) {
-    options = options || {};
+    options = this.extend(true, {}, options) || {};
     options = SIP.Utils.desugarSessionOptions(options);
     SIP.Utils.optionsOverride(options, 'media', 'mediaConstraints', true, this.logger, this.ua.configuration.media);
     this.mediaHint = options.media;

--- a/src/UA.js
+++ b/src/UA.js
@@ -256,7 +256,7 @@ UA.prototype.afterConnected = function afterConnected (callback) {
  *
  */
 UA.prototype.invite = function(target, options) {
-  options = SIP.Utils.copy(options) || {};
+  options = options || {};
   options = SIP.Utils.desugarSessionOptions(options);
   SIP.Utils.optionsOverride(options, 'media', 'mediaConstraints', true, this.logger);
 

--- a/src/UA.js
+++ b/src/UA.js
@@ -256,7 +256,7 @@ UA.prototype.afterConnected = function afterConnected (callback) {
  *
  */
 UA.prototype.invite = function(target, options) {
-  options = options || {};
+  options = SIP.Utils.copy(options) || {};
   options = SIP.Utils.desugarSessionOptions(options);
   SIP.Utils.optionsOverride(options, 'media', 'mediaConstraints', true, this.logger);
 

--- a/src/UA.js
+++ b/src/UA.js
@@ -8,6 +8,9 @@
  * @param {Object} [configuration.media] gets passed to SIP.MediaHandler.getDescription as mediaHint
  */
 module.exports = function (SIP) {
+
+var extend = require('extend');
+
 var UA,
   C = {
     // UA status codes
@@ -78,6 +81,8 @@ UA = function(configuration) {
 
   this.log = new SIP.LoggerFactory();
   this.logger = this.getLogger('sip.ua');
+
+  this.extend = extend;
 
   this.cache = {
     credentials: {}
@@ -256,7 +261,7 @@ UA.prototype.afterConnected = function afterConnected (callback) {
  *
  */
 UA.prototype.invite = function(target, options) {
-  options = options || {};
+  options = this.extend(true, {}, options) || {};
   options = SIP.Utils.desugarSessionOptions(options);
   SIP.Utils.optionsOverride(options, 'media', 'mediaConstraints', true, this.logger);
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -92,6 +92,17 @@ Utils= {
     return 'v=0\r\n' + body.slice(start, end) + '\r\ns=-\r\nt=0 0\r\nc=IN IP4 0.0.0.0';
   },
 
+  copy: function(source) {
+    var copy = {}, prop;
+
+    for (prop in source) {
+      if (hasOwnProperty.call(source, prop)) {
+        copy[prop] = source[prop];
+      }
+    }
+    return copy;
+  },
+
   isFunction: function(fn) {
     if (fn !== undefined) {
       return Object.prototype.toString.call(fn) === '[object Function]';

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -92,17 +92,6 @@ Utils= {
     return 'v=0\r\n' + body.slice(start, end) + '\r\ns=-\r\nt=0 0\r\nc=IN IP4 0.0.0.0';
   },
 
-  copy: function(source) {
-    var copy = {}, prop;
-
-    for (prop in source) {
-      if (hasOwnProperty.call(source, prop)) {
-        copy[prop] = source[prop];
-      }
-    }
-    return copy;
-  },
-
   isFunction: function(fn) {
     if (fn !== undefined) {
       return Object.prototype.toString.call(fn) === '[object Function]';

--- a/test/spec/SpecUA.js
+++ b/test/spec/SpecUA.js
@@ -430,7 +430,6 @@ describe('UA', function() {
 
       var options = {};
       UA.configuration.mediaHandlerFactory = function(){};
-      SIP.Utils.copy = function(){ return options; };
       UA.invite(target,options);
       // invite() puts the mediaHandlerFactory into the options object
       expect(SIP.InviteClientContext).toHaveBeenCalledWith(UA, target, options);

--- a/test/spec/SpecUA.js
+++ b/test/spec/SpecUA.js
@@ -443,7 +443,7 @@ describe('UA', function() {
 
     beforeEach(function() {
       target = 'target';
-      event = 'event'
+      event = 'event';
       subscribeSpy = jasmine.createSpy('subscribe');
 
       spyOn(SIP, 'Subscription').and.returnValue({

--- a/test/spec/SpecUA.js
+++ b/test/spec/SpecUA.js
@@ -430,6 +430,7 @@ describe('UA', function() {
 
       var options = {};
       UA.configuration.mediaHandlerFactory = function(){};
+      SIP.Utils.copy = function(){ return options; };
       UA.invite(target,options);
       // invite() puts the mediaHandlerFactory into the options object
       expect(SIP.InviteClientContext).toHaveBeenCalledWith(UA, target, options);

--- a/test/spec/SpecUA.js
+++ b/test/spec/SpecUA.js
@@ -426,13 +426,19 @@ describe('UA', function() {
     });
 
     it('creates an Invite Client Context with itself, target, and options as parameters', function() {
-      spyOn(UA, 'isConnected').and.returnValue(true);
+      var options = {},
+          extendedOptions = {};
 
-      var options = {};
+      spyOn(UA, 'isConnected').and.returnValue(true);
+      spyOn(UA, 'extend').and.returnValue(extendedOptions);
+
       UA.configuration.mediaHandlerFactory = function(){};
-      UA.invite(target,options);
-      // invite() puts the mediaHandlerFactory into the options object
-      expect(SIP.InviteClientContext).toHaveBeenCalledWith(UA, target, options);
+      UA.invite(target, options);
+      // invite() puts the mediaHandlerFactory into the extendedOptions object
+      expect(SIP.InviteClientContext).toHaveBeenCalledWith(UA, target, extendedOptions);
+    });
+
+    it('', function() {
     });
   });
 


### PR DESCRIPTION
I ran into the following situation today:
After a call to UA.invite:

    userAgent.invite("xyz@test.org", myopts);

The myopts object had a `extraHeaders` properties added.
(Session L1600).

The problem is if you have a setup like this:

      var myopts = {
        media: {
          constraints: {
            audio: true,
            video: true
          },
          render: {
            remote: {
              video: document.getElementById("remoteVideo")
            },
            local: {
              video: document.getElementById("localVideo")
            }
          }
        }
      };

    document.getElementById("callButton").onclick = function() {
      session = userAgent.invite("xyz@test.org", myopts);
      console.log(myopts);
    };

where you re-use the myopts object, you keep `push`ing extraHeaders
`Contact:` and `Allow:` and finally sending these with your invites.
I thought that a copy of the user-submitted object might be the cleanest
solution to this problem. But of course I'm open to other suggestions (and
alternative implementations of the copy functionality).