### PR TITLE
Makes options to RegisterContext's register "instance" properties.

### DIFF
--- a/src/RegisterContext.js
+++ b/src/RegisterContext.js
@@ -48,13 +48,13 @@ RegisterContext = function (ua) {
 
 RegisterContext.prototype = {
   register: function (options) {
-    var self = this;
+    var self = this, extraHeaders;
 
     // Handle Options
     this.options = options || {};
-    this.extraHeaders = (this.options.extraHeaders || []).slice();
-    this.extraHeaders.push('Contact: ' + this.contact + ';expires=' + this.expires);
-    this.extraHeaders.push('Allow: ' + SIP.Utils.getAllowedMethods(this.ua));
+    extraHeaders = (this.options.extraHeaders || []).slice();
+    extraHeaders.push('Contact: ' + this.contact + ';expires=' + this.expires);
+    extraHeaders.push('Allow: ' + SIP.Utils.getAllowedMethods(this.ua));
 
     this.receiveResponse = function(response) {
       var contact, expires,
@@ -166,7 +166,7 @@ RegisterContext.prototype = {
     this.cseq++;
     this.request.cseq = this.cseq;
     this.request.setHeader('cseq', this.cseq + ' REGISTER');
-    this.request.extraHeaders = this.extraHeaders;
+    this.request.extraHeaders = extraHeaders;
     this.send();
   },
 

--- a/src/RegisterContext.js
+++ b/src/RegisterContext.js
@@ -48,13 +48,13 @@ RegisterContext = function (ua) {
 
 RegisterContext.prototype = {
   register: function (options) {
-    var self = this, extraHeaders;
+    var self = this;
 
     // Handle Options
-    options = options || {};
-    extraHeaders = (options.extraHeaders || []).slice();
-    extraHeaders.push('Contact: ' + this.contact + ';expires=' + this.expires);
-    extraHeaders.push('Allow: ' + SIP.Utils.getAllowedMethods(this.ua));
+    this.options = options || {};
+    this.extraHeaders = (this.options.extraHeaders || []).slice();
+    this.extraHeaders.push('Contact: ' + this.contact + ';expires=' + this.expires);
+    this.extraHeaders.push('Allow: ' + SIP.Utils.getAllowedMethods(this.ua));
 
     this.receiveResponse = function(response) {
       var contact, expires,
@@ -117,7 +117,7 @@ RegisterContext.prototype = {
           // For that, decrease the expires value. ie: 3 seconds
           this.registrationTimer = SIP.Timers.setTimeout(function() {
             self.registrationTimer = null;
-            self.register(options);
+            self.register(this.options);
           }, (expires * 1000) - 3000);
           this.registrationExpiredTimer = SIP.Timers.setTimeout(function () {
             self.logger.warn('registration expired');
@@ -143,7 +143,7 @@ RegisterContext.prototype = {
             // Increase our registration interval to the suggested minimum
             this.expires = response.getHeader('min-expires');
             // Attempt the registration again immediately
-            this.register(options);
+            this.register(this.options);
           } else { //This response MUST contain a Min-Expires header field
             this.logger.warn('423 response received for REGISTER without Min-Expires');
             this.registrationFailure(response, SIP.C.causes.SIP_FAILURE_CODE);
@@ -166,7 +166,7 @@ RegisterContext.prototype = {
     this.cseq++;
     this.request.cseq = this.cseq;
     this.request.setHeader('cseq', this.cseq + ' REGISTER');
-    this.request.extraHeaders = extraHeaders;
+    this.request.extraHeaders = this.extraHeaders;
     this.send();
   },
 
@@ -192,7 +192,7 @@ RegisterContext.prototype = {
   },
 
   onTransportConnected: function() {
-    this.register();
+    this.register(this.options);
   },
 
   close: function() {

--- a/test/spec/SpecRegisterContext.js
+++ b/test/spec/SpecRegisterContext.js
@@ -137,12 +137,15 @@ describe('RegisterContext', function() {
   
   describe('.onTransportConnected', function(){
     it('calls register', function() {
+      var options = { traceSip: true, extraHeaders: [ 'X-Foo: foo', 'X-Bar: bar' ] };
+      RegisterContext.options = options;
+
       spyOn(RegisterContext, 'register').and.returnValue('register');
       expect(RegisterContext.register).not.toHaveBeenCalled();
-      
+
       RegisterContext.onTransportConnected();
-      
-      expect(RegisterContext.register).toHaveBeenCalledWith();
+
+      expect(RegisterContext.register).toHaveBeenCalledWith(options);
     });
   });
   


### PR DESCRIPTION
For example:

```javascript
userAgent = new SIP.UA({
  ...
  traceSip: true,
  register: false
});

userAgent.register({traceSip: false, extraHeaders: [ 'X-Foo: foo', 'X-Bar: bar' ] });
```

`RegisterContext` receives the options via

`register({traceSip: false, extraHeaders: [ 'X-Foo: foo', 'X-Bar: bar' ] })`

before the connection to the socket is established. 

Once the transport is connected
`RegisterContext's.onTransportConnected` is called and registers with empty
options.

This commit changes the options so that the RegisterContext saves them
as 'instance properties', which allows for calling onTransportConnected
with the register options.

Although it feels a little weird calling: `this.register(this.options);`
I like the way the options provided to `userAgent.register()` will always overwrite
the instance properties. 

But as always please feel free to critique and make suggestions!
Hope I didn't miss anything. Noticed this while working on another PR.