### PR TITLE
Improve the WebSocket error reporting

### DIFF
--- a/src/Transport.js
+++ b/src/Transport.js
@@ -265,7 +265,7 @@ Transport.prototype = {
   * @param {event} e
   */
   onError: function(e) {
-    this.logger.warn('WebSocket connection error: ' + e);
+    this.logger.warn('WebSocket connection error: ' + JSON.stringify(e));
   },
 
   /**


### PR DESCRIPTION
If your encounter a WebSocket connection problem the current error message reports as:
"Thu Apr 02 2015 16:14:18 GMT-0500 (CDT) | sip.transport | WebSocket connection error: [object Event]" sip.js:2636

If you instead stringify the error object before appending it you will get more useful information.