### PR TITLE
Re-enable receiving reINVITEs

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -663,9 +663,7 @@ Session.prototype = {
       case SIP.C.INVITE:
         if(this.status === C.STATUS_CONFIRMED) {
           this.logger.log('re-INVITE received');
-          // Switch these two lines to try re-INVITEs:
-          //this.receiveReinvite(request);
-          request.reply(488, null, ['Warning: 399 sipjs "Cannot update media description"']);
+          this.receiveReinvite(request);
         }
         break;
       case SIP.C.INFO:

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -1595,7 +1595,7 @@ describe('InviteServerContext', function() {
     });
 
     describe('method is INVITE', function() {
-      xit('calls receiveReinvite', function() {
+      it('calls receiveReinvite', function() {
         InviteServerContext.status = 12;
         req = SIP.Parser.parseMessage([
           'INVITE sip:gled5gsn@hk95bautgaa7.invalid;transport=ws;aor=james%40onsnip.onsip.com SIP/2.0',
@@ -2459,7 +2459,7 @@ describe('InviteClientContext', function() {
       expect(InviteClientContext.terminated).toHaveBeenCalledWith(request, SIP.C.causes.BYE);
     });
 
-    xit('logs and calls receiveReinvite if request method is INVITE', function() {
+    it('logs and calls receiveReinvite if request method is INVITE', function() {
       InviteClientContext.status = 12;
       request.method = SIP.C.INVITE;
 


### PR DESCRIPTION
Browsers have gotten better at renegotiation (now that [Firefox 38 is out](https://hacks.mozilla.org/2015/03/webrtc-in-firefox-38-multistream-and-renegotiation/)), so let's consider turning this back on.