### PR TITLE
Unwrap terminated data

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -945,10 +945,10 @@ Session.prototype = {
     this.endTime = new Date();
 
     this.close();
-    this.emit('terminated', {
-      message: message || null,
-      cause: cause || null
-    });
+    this.emit('terminated',
+      message || null,
+      cause || null
+    );
     return this;
   },
 


### PR DESCRIPTION
The terminated event currently wraps its callback data in an object,
making it inconsistent with the docs (as well as how the other events
operate). This change simply unwraps it.