### PR TITLE
Allow uppercase host

### DIFF
--- a/src/Grammar/src/Grammar.pegjs
+++ b/src/Grammar/src/Grammar.pegjs
@@ -130,7 +130,7 @@ password        = ( unreserved / escaped / "&" / "=" / "+" / "$" / "," )* {
 hostport        = host ( ":" port )?
 
 host            = ( hostname / IPv4address / IPv6reference ) {
-                    options.data.host = text().toLowerCase();
+                    options.data.host = text();
                     return options.data.host; }
 
 hostname        = ( domainlabel "." )* toplabel  "." ? {


### PR DESCRIPTION
It doesn't seem like the rfc3261 spec requires host to be lowercase, and in some cases this is limiting.

Relevant specifications can be found at https://www.ietf.org/rfc/rfc3261.txt on page 222.