### PR TITLE
Prevent simultaneous UA starts

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -12,10 +12,11 @@ module.exports = function (SIP, environment) {
 var UA,
   C = {
     // UA status codes
-    STATUS_INIT :                0,
-    STATUS_READY:                1,
-    STATUS_USER_CLOSED:          2,
-    STATUS_NOT_READY:            3,
+    STATUS_INIT:                0,
+    STATUS_STARTING:            1,
+    STATUS_READY:               2,
+    STATUS_USER_CLOSED:         3,
+    STATUS_NOT_READY:           4,
 
     // UA error codes
     CONFIGURATION_ERROR:  1,
@@ -362,11 +363,14 @@ UA.prototype.start = function() {
   this.logger.log('user requested startup...');
   if (this.status === C.STATUS_INIT) {
     server = this.getNextWsServer();
+    this.status = C.STATUS_STARTING;
     new SIP.Transport(this, server);
   } else if(this.status === C.STATUS_USER_CLOSED) {
     this.logger.log('resuming');
     this.status = C.STATUS_READY;
     this.transport.connect();
+  } else if (this.status === C.STATUS_STARTING) {
+    this.logger.log('UA is in STARTING status, not opening new connection');
   } else if (this.status === C.STATUS_READY) {
     this.logger.log('UA is in READY status, not resuming');
   } else {

--- a/test/spec/SpecUA.js
+++ b/test/spec/SpecUA.js
@@ -155,13 +155,19 @@ describe('UA', function() {
       expect(UA.status).toBe(SIP.UA.C.STATUS_READY);
     });
 
+    it('logs if the status is set to starting', function() {
+      UA.status = SIP.UA.C.STATUS_STARTING;
+      UA.start();
+      expect(UA.logger.log).toHaveBeenCalled();
+    });
+
     it('logs if the status is set to ready', function() {
       UA.status = SIP.UA.C.STATUS_READY;
       UA.start();
       expect(UA.logger.log).toHaveBeenCalled();
     });
 
-    it('logs an error if the status is not C.STATUS_INIT, C.STATUS_USER_CLOSED, C.STATUS_READY', function() {
+    it('logs an error if the status is not C.STATUS_INIT, C.STATUS_STARTING, C.STATUS_USER_CLOSED, C.STATUS_READY', function() {
       UA.status = SIP.UA.C.STATUS_NOT_READY;
       UA.start();
       expect(UA.logger.error).toHaveBeenCalled();
@@ -183,7 +189,7 @@ describe('UA', function() {
     });
 
     it('logs a warning and returns this if the ua has already been closed', function () {
-      UA.status = 2;
+      UA.status = 3;
 
       expect(UA.stop()).toBe(UA);
       expect(UA.logger.warn).toHaveBeenCalledWith('UA already closed');


### PR DESCRIPTION
Running into an issue where multiple calls to UA.start() before the UA has connected will result in multiple open web sockets. It's possible to prevent this in our implementation, but this seems like logic that belongs on the UA, and other SIPjs users may benefit from.