### PR TITLE
Fix reregister options

### DIFF
--- a/src/RegisterContext.js
+++ b/src/RegisterContext.js
@@ -112,7 +112,7 @@ RegisterContext.prototype = {
           // For that, decrease the expires value. ie: 3 seconds
           this.registrationTimer = SIP.Timers.setTimeout(function() {
             self.registrationTimer = null;
-            self.register(this.options);
+            self.register(self.options);
           }, (expires * 1000) - 3000);
           this.registrationExpiredTimer = SIP.Timers.setTimeout(function () {
             self.logger.warn('registration expired');


### PR DESCRIPTION
We're inside an anonymous function so `this` doesn't refer to the `RegisterContext`. Changed to `self` so that options are properly re-sent on re-register.