### PR TITLE
Pass options to unregister on close

### DIFF
--- a/src/RegisterContext.js
+++ b/src/RegisterContext.js
@@ -192,7 +192,7 @@ RegisterContext.prototype = {
 
   close: function() {
     this.registered_before = this.registered;
-    this.unregister();
+    this.unregister(this.options);
   },
 
   unregister: function(options) {

--- a/test/spec/SpecRegisterContext.js
+++ b/test/spec/SpecRegisterContext.js
@@ -159,10 +159,11 @@ describe('RegisterContext', function() {
       expect(RegisterContext.registered).toBe(RegisterContext.registered_before);
     });
     
-    it('calls unregister', function() {
+    it('calls unregister with RegisterContext\'s stored options', function() {
       expect(RegisterContext.unregister).not.toHaveBeenCalled();
+      RegisterContext.options = { foo: 'bar' };
       RegisterContext.close();
-      expect(RegisterContext.unregister).toHaveBeenCalledWith();
+      expect(RegisterContext.unregister).toHaveBeenCalledWith(RegisterContext.options);
     });
   });
   


### PR DESCRIPTION
We've run into a problem where we need to pass authorization headers to both register and unregister. This is easy to handle with register and unregister directly, but close doesn't seem to utilize our stored register options. This PR simply changes the `RegisterContext.close` function to pass `this.options` to `this.unregister()`.