### PR TITLE
Allow uppercase host

### DIFF
--- a/src/Grammar/src/Grammar.pegjs
+++ b/src/Grammar/src/Grammar.pegjs
@@ -130,7 +130,7 @@ password        = ( unreserved / escaped / "&" / "=" / "+" / "$" / "," )* {
 hostport        = host ( ":" port )?
 
 host            = ( hostname / IPv4address / IPv6reference ) {
-                    options.data.host = text().toLowerCase();
+                    options.data.host = text();
                     return options.data.host; }
 
 hostname        = ( domainlabel "." )* toplabel  "." ? {

--- a/test/spec/SpecGrammar.js
+++ b/test/spec/SpecGrammar.js
@@ -60,7 +60,7 @@ describe('Grammar', function () {
 
         uriHas('scheme', 'sip');
         uriHas('user', '+1234');
-        uriHas('host', 'aliax.net');
+        uriHas('host', 'ALIAX.net');
         uriHas('port', undefined);
 
         uriReturns('getParam', 'transport', 'ws');
@@ -78,7 +78,7 @@ describe('Grammar', function () {
         c1.setParam('New-Param', null);
         expect(c1.hasParam('NEW-param')).toEqual(true);
         c1.uri.setParam('New-Param', null);
-        expect(c1.toString()).toEqual('"€€€" <sip:+999@aliax.net;transport=ws;new-param>;+sip.instance="zxCV";new-param');
+        expect(c1.toString()).toEqual('"€€€" <sip:+999@ALIAX.net;transport=ws;new-param>;+sip.instance="zxCV";new-param');
       });
     });
 
@@ -96,7 +96,7 @@ describe('Grammar', function () {
       c2Has('displayName', undefined);
 
       c2Returns('hasParam', 'HEADERPARAM', true);
-      c2Returns('toString', null, '<sip:bob@biloxi.com>;headerparam');
+      c2Returns('toString', null, '<sip:bob@biloxi.COM>;headerparam');
 
       describe('its URI', function () {
         var uriThunk = function () { return c2.uri; };
@@ -108,14 +108,14 @@ describe('Grammar', function () {
 
         uriHas('scheme', 'sip');
         uriHas('user', 'bob');
-        uriHas('host', 'biloxi.com');
+        uriHas('host', 'biloxi.COM');
         uriHas('port', undefined);
 
         itsMethodReturns(uriThunk, 'hasParam', 'headerParam', false);
 
         it('can alter display name', function () {
           c2.displayName = '@ł€ĸłæß';
-          expect(c2.toString()).toEqual('"@ł€ĸłæß" <sip:bob@biloxi.com>;headerparam');
+          expect(c2.toString()).toEqual('"@ł€ĸłæß" <sip:bob@biloxi.COM>;headerparam');
         });
       });
     });
@@ -129,7 +129,7 @@ describe('Grammar', function () {
 
       var c3Thunk = function () { return c3; };
       itHas(c3Thunk, 'displayName', undefined);
-      itsMethodReturns(c3Thunk, 'toString', null, '<sips:domain.com:5>');
+      itsMethodReturns(c3Thunk, 'toString', null, '<sips:DOMAIN.com:5>');
 
       describe('its URI', function () {
         var uriThunk = function () { return c3.uri; };
@@ -141,7 +141,7 @@ describe('Grammar', function () {
 
         uriHas('scheme', 'sips');
         uriHas('user', undefined);
-        uriHas('host', 'domain.com');
+        uriHas('host', 'DOMAIN.com');
         uriHas('port', 5);
 
         itsMethodReturns(uriThunk, 'hasParam', 'nooo', false);
@@ -149,7 +149,7 @@ describe('Grammar', function () {
         it('can set header params and uri params', function () {
           c3.uri.setParam('newUriParam', 'zxCV');
           c3.setParam('newHeaderParam', 'zxCV');
-          expect(c3.toString()).toEqual('<sips:domain.com:5;newuriparam=zxcv>;newheaderparam=zxCV');
+          expect(c3.toString()).toEqual('<sips:DOMAIN.com:5;newuriparam=zxcv>;newheaderparam=zxCV');
         });
       });
     });

--- a/test/spec/SpecNameAddrHeader.js
+++ b/test/spec/SpecNameAddrHeader.js
@@ -135,7 +135,7 @@ describe('NameAddrHeader', function() {
     it('can set the display name to ' + newDispName, function () {
       header.displayName = newDispName;
       expect(header.displayName).toEqual(newDispName);
-      expect(header.toString()).toEqual('<sip:aliCE@versatica.com:6060;transport=tcp;foo=abc;baz?X-Header-1=AaA1&X-Header-1=AAA2&X-Header-2=BbB>;qwe=QWE;asd');
+      expect(header.toString()).toEqual('<sip:aliCE@versaTICA.Com:6060;transport=tcp;foo=abc;baz?X-Header-1=AaA1&X-Header-1=AAA2&X-Header-2=BbB>;qwe=QWE;asd');
     });
 
     describe('its URI:', function () {
@@ -147,7 +147,7 @@ describe('NameAddrHeader', function() {
 
       itsUriParses('scheme', 'sip');
       itsUriParses('user', 'aliCE');
-      itsUriParses('host', 'versatica.com');
+      itsUriParses('host', 'versaTICA.Com');
       itsUriParses('port', 6060);
 
       function itsUriMethod (methodName, methodArg, expected) {

--- a/test/spec/SpecNormalizeTarget.js
+++ b/test/spec/SpecNormalizeTarget.js
@@ -23,7 +23,7 @@ describe('Utils.normalizeTarget', function() {
 
     test_ok('%61lice', 'sip:alice@sip.js.net');
     test_ok('ALICE', 'sip:ALICE@sip.js.net');
-    test_ok('alice@DOMAIN.com', 'sip:alice@domain.com');
+    test_ok('alice@DOMAIN.com', 'sip:alice@DOMAIN.com');
     test_ok('iñaki', 'sip:i%C3%B1aki@sip.js.net');
     test_ok('€€€', 'sip:%E2%82%AC%E2%82%AC%E2%82%AC@sip.js.net');
     test_ok('iñaki@aliax.net', 'sip:i%C3%B1aki@aliax.net');
@@ -33,8 +33,8 @@ describe('Utils.normalizeTarget', function() {
     test_ok('alice-1:passwd', 'sip:alice-1:passwd@sip.js.net');
     test_ok('SIP:alice-2:passwd', 'sip:alice-2:passwd@sip.js.net');
     test_ok('sips:alice-2:passwd', 'sip:alice-2:passwd@sip.js.net');
-    test_ok('alice-3:passwd@domain.COM', 'sip:alice-3:passwd@domain.com');
-    test_ok('SIP:alice-4:passwd@domain.COM', 'sip:alice-4:passwd@domain.com');
+    test_ok('alice-3:passwd@domain.COM', 'sip:alice-3:passwd@domain.COM');
+    test_ok('SIP:alice-4:passwd@domain.COM', 'sip:alice-4:passwd@domain.COM');
     test_ok('sip:+1234@aliax.net', 'sip:+1234@aliax.net');
     test_ok('+999', 'sip:+999@sip.js.net');
     test_ok('*999', 'sip:*999@sip.js.net');

--- a/test/spec/SpecURI.js
+++ b/test/spec/SpecURI.js
@@ -302,7 +302,7 @@ describe("URI", function() {
     expect(parsedURI).toBeUndefined();
   });
 
-  var toParse = 'SIP:%61liCE@versaTICA.Com:6060;TRansport=TCp;Foo=ABc;baz?X-Header-1=AaA1&X-Header-2=BbB&x-header-1=AAA2';
+  var toParse = 'SIP:%61liCE@versaTICA.com:6060;TRansport=TCp;Foo=ABc;baz?X-Header-1=AaA1&X-Header-2=BbB&x-header-1=AAA2';
 
   describe('URI.parse with "' + toParse + '"', function () {
     var uri;
@@ -323,7 +323,7 @@ describe("URI", function() {
 
     itParses('scheme', 'sip');
     itParses('user', 'aliCE');
-    itParses('host', 'versatica.com');
+    itParses('host', 'versaTICA.com');
     itParses('port', 6060);
 
     it('parses non-null parameter "transport"', function () {
@@ -347,7 +347,7 @@ describe("URI", function() {
     itsMethod('parses header list x-header-1', 'getHeader', 'x-header-1', ['AaA1', 'AAA2']);
     itsMethod('parses header X-HEADER-2', 'getHeader', 'X-HEADER-2', ['BbB']);
     itsMethod('doesn\'t parse missing header "nooo"', 'getHeader', 'nooo', undefined);
-    itsMethod('correctly toString()s itself', 'toString', undefined, 'sip:aliCE@versatica.com:6060;transport=tcp;foo=abc;baz?X-Header-1=AaA1&X-Header-1=AAA2&X-Header-2=BbB');
+    itsMethod('correctly toString()s itself', 'toString', undefined, 'sip:aliCE@versaTICA.com:6060;transport=tcp;foo=abc;baz?X-Header-1=AaA1&X-Header-1=AAA2&X-Header-2=BbB');
 
     var newUser = 'Iñaki:PASSWD';
     describe('when setting the user to "' + newUser + '"', function () {
@@ -362,14 +362,14 @@ describe("URI", function() {
       it('can delete parameter "foo" and delete header "x-header-1"', function () {
         expect(uri.deleteParam('foo')).toEqual('abc');
         expect(uri.deleteHeader('x-header-1')).toEqual(['AaA1', 'AAA2']);
-        expect(uri.toString()).toEqual('sip:I%C3%B1aki:PASSWD@versatica.com:6060;transport=tcp;baz?X-Header-2=BbB');
+        expect(uri.toString()).toEqual('sip:I%C3%B1aki:PASSWD@versaTICA.com:6060;transport=tcp;baz?X-Header-2=BbB');
       });
 
       it('can clear parameters and headers, and nullify the port', function () {
         uri.clearParams();
         uri.clearHeaders();
         uri.port = null;
-        expect(uri.toString()).toEqual('sip:I%C3%B1aki:PASSWD@versatica.com');
+        expect(uri.toString()).toEqual('sip:I%C3%B1aki:PASSWD@versaTICA.com');
       });
     });
   });


### PR DESCRIPTION
Is there a specific reason that hosts are automatically lower-cased?

Our SIP addresses follow this scheme:

```
sip://clientName@accountID.foobar.com
```

Where clientName is the client's name as registered with SIP and accountID is the user's account. An account can have multiple named clients.

However, our accountIDs are case-sensitive and contain capital letters. Is there a reason case-insensitivity is being enforced on this level or might these be a case of over-fitting?