### PR TITLE
Override receiveResponse for .refer()

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -236,7 +236,7 @@ Session.prototype = {
     this.sendRequest(SIP.C.REFER, {
       extraHeaders: extraHeaders,
       body: options.body,
-      receiveResponse: function (response) {
+      receiveResponse: options.receiveResponse || function (response) {
         if ( ! /^2[0-9]{2}$/.test(response.status_code) ) {
           return;
         }
@@ -720,6 +720,9 @@ Session.prototype = {
             this.emit('refer', request);
           }
         }
+        break;
+      case SIP.C.NOTIFY:
+        request.reply(200, 'OK');
         break;
     }
   },


### PR DESCRIPTION
I'd like to use `refer` for the "Requesting a Focus to Add a New Resource to a Conference" use case described in [RFC 4579, Section 5.5](https://tools.ietf.org/html/rfc4579#section-5.5). Would you be open to allowing developers to override SIP.js's existing behavior in `receiveResponse`?

Also, I found that a 200 OK would not be sent to the NOTIFY unless explicitly handled.