### PR TITLE
Expand keep-alive support

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -884,6 +884,8 @@ UA.prototype.loadConfig = function(configuration) {
       connectionRecoveryMinInterval: 2,
       connectionRecoveryMaxInterval: 30,
 
+      keepAliveInterval: 0,
+
       usePreloadedRoute: false,
 
       //string to be inserted into User-Agent request header
@@ -1114,6 +1116,7 @@ UA.configuration_skeleton = (function() {
       "authorizationUser",
       "connectionRecoveryMaxInterval",
       "connectionRecoveryMinInterval",
+      "keepAliveInterval",
       "displayName",
       "hackViaTcp", // false.
       "hackIpInContact", //false
@@ -1323,6 +1326,16 @@ UA.configuration_check = {
         return;
       } else {
         return instanceId;
+      }
+    },
+
+    keepAliveInterval: function(keepAliveInterval) {
+      var value;
+      if (SIP.Utils.isDecimal(keepAliveInterval)) {
+        value = Number(keepAliveInterval);
+        if (value > 0) {
+          return value;
+        }
       }
     },
 


### PR DESCRIPTION
SIP.js recognizes [keep-alive responses](https://github.com/onsip/SIP.js/blob/608407e6153e7a65c5c48c2f140fb4a943e4b5d6/src/Transport.js#L202). What do you think about enabling keep-alive requests?

We could expose this through a UA configuration option, `keepAliveInterval`, to set the upper bound for sending double-CRLF keep-alives as described in [RFC 5626, Section 4.4.1](https://tools.ietf.org/html/rfc5626#section-4.4.1). `keepAliveInterval` defaults to zero, which disables sending keep-alives.

Open questions:

- Detecting the `Flow-Timer` header and updating the `keepAliveInterval`
- Detecting when a pong has not been received for 10 seconds