### PR TITLE
Use raw address URIs over SIP

### DIFF
--- a/src/Grammar/src/Grammar.pegjs
+++ b/src/Grammar/src/Grammar.pegjs
@@ -115,7 +115,7 @@ SIP_URI         = uri_scheme ":"  userinfo ? hostport uri_parameters headers ? {
                       }
 
 uri_scheme      = uri_scheme:  ( "sips"i / "sip"i ) {
-                    options.data.scheme = uri_scheme.toLowerCase(); }
+                    options.data.scheme = uri_scheme; }
 
 userinfo        = user (":" password)? "@" {
                     options.data.user = decodeURIComponent(text().slice(0, -1));}
@@ -130,7 +130,7 @@ password        = ( unreserved / escaped / "&" / "=" / "+" / "$" / "," )* {
 hostport        = host ( ":" port )?
 
 host            = ( hostname / IPv4address / IPv6reference ) {
-                    options.data.host = text().toLowerCase();
+                    options.data.host = text();
                     return options.data.host; }
 
 hostname        = ( domainlabel "." )* toplabel  "." ? {

--- a/src/SIPMessage.js
+++ b/src/SIPMessage.js
@@ -27,7 +27,9 @@ OutgoingRequest = function(method, ruri, ua, params, extraHeaders, body) {
     to,
     from,
     call_id,
-    cseq;
+    cseq,
+    to_uri,
+    from_uri;
 
   params = params || {};
 
@@ -63,13 +65,15 @@ OutgoingRequest = function(method, ruri, ua, params, extraHeaders, body) {
   this.setHeader('max-forwards', SIP.UA.C.MAX_FORWARDS);
 
   // To
+  to_uri = params.to_uri || ruri;
   to = (params.to_displayName || params.to_displayName === 0) ? '"' + params.to_displayName + '" ' : '';
-  to += '<' + (params.to_uri || ruri) + '>';
+  to += '<' + (to_uri && to_uri.toRaw ? to_uri.toRaw() : to_uri) + '>';
   to += params.to_tag ? ';tag=' + params.to_tag : '';
   this.to = new SIP.NameAddrHeader.parse(to);
   this.setHeader('to', to);
 
   // From
+  from_uri = params.from_uri || ua.configuration.uri;
   if (params.from_displayName || params.from_displayName === 0) {
     from = '"' + params.from_displayName + '" ';
   } else if (ua.configuration.displayName) {
@@ -77,7 +81,7 @@ OutgoingRequest = function(method, ruri, ua, params, extraHeaders, body) {
   } else {
     from = '';
   }
-  from += '<' + (params.from_uri || ua.configuration.uri) + '>;tag=';
+  from += '<' + (from_uri && from_uri.toRaw ? from_uri.toRaw() : from_uri) + '>;tag=';
   from += params.from_tag || SIP.Utils.newTag();
   this.from = new SIP.NameAddrHeader.parse(from);
   this.setHeader('from', from);
@@ -185,7 +189,7 @@ OutgoingRequest.prototype = {
   toString: function() {
     var msg = '', header, length, idx, supported = [];
 
-    msg += this.method + ' ' + this.ruri + ' SIP/2.0\r\n';
+    msg += this.method + ' ' + (this.ruri.toRaw ? this.ruri.toRaw() : this.ruri) + ' SIP/2.0\r\n';
 
     for (header in this.headers) {
       length = this.headers[header].length;

--- a/src/UA.js
+++ b/src/UA.js
@@ -1010,7 +1010,7 @@ UA.prototype.loadConfig = function(configuration) {
   // String containing settings.uri without scheme and user.
   hostportParams = settings.uri.clone();
   hostportParams.user = null;
-  settings.hostportParams = hostportParams.toString().replace(/^sip:/i, '');
+  settings.hostportParams = hostportParams.toRaw().replace(/^sip:/i, '');
 
   /* Check whether authorizationUser is explicitly defined.
    * Take 'settings.uri.user' value if not.

--- a/src/URI.js
+++ b/src/URI.js
@@ -19,7 +19,7 @@ module.exports = function (SIP) {
 var URI;
 
 URI = function(scheme, user, host, port, parameters, headers) {
-  var param, header;
+  var param, header, raw, normal;
 
   // Checks
   if(!host) {
@@ -38,41 +38,68 @@ URI = function(scheme, user, host, port, parameters, headers) {
   for (header in headers) {
     this.setHeader(header, headers[header]);
   }
+  
+  // Raw URI
+  raw = {
+    scheme: scheme,
+    user: user,
+    host: host,
+    port: port
+  };
+
+  // Normalized URI
+  normal = {
+    scheme: scheme.toLowerCase(),
+    user: user,
+    host: host.toLowerCase(),
+    port: port
+  };
 
   Object.defineProperties(this, {
+    _normal: {
+      get: function() { return normal; }
+    },
+
+    _raw: {
+      get: function() { return raw; }
+    },
+
     scheme: {
-      get: function(){ return scheme; },
-      set: function(value){
-        scheme = value.toLowerCase();
+      get: function() { return normal.scheme; },
+      set: function(value) {
+        raw.scheme = value;
+        normal.scheme = value.toLowerCase();
       }
     },
 
     user: {
-      get: function(){ return user; },
-      set: function(value){
-        user = value;
+      get: function() { return normal.user; },
+      set: function(value) {
+        normal.user = raw.user = value;
       }
     },
 
     host: {
-      get: function(){ return host; },
-      set: function(value){
-        host = value.toLowerCase();
+      get: function() { return normal.host; },
+      set: function(value) {
+        raw.host = value;
+        normal.host = value.toLowerCase();
       }
     },
 
     aor: {
-      get: function(){ return user + '@' + host; }
+      get: function() { return normal.user + '@' + normal.host; }
     },
 
     port: {
-      get: function(){ return port; },
-      set: function(value){
-        port = value === 0 ? value : (parseInt(value,10) || null);
+      get: function() { return normal.port; },
+      set: function(value) {
+        normal.port = raw.port = value === 0 ? value : (parseInt(value,10) || null);
       }
     }
   });
 };
+
 URI.prototype = {
   setParam: function(key, value) {
     if(key) {
@@ -138,36 +165,43 @@ URI.prototype = {
 
   clone: function() {
     return new URI(
-      this.scheme,
-      this.user,
-      this.host,
-      this.port,
+      this._raw.scheme,
+      this._raw.user,
+      this._raw.host,
+      this._raw.port,
       JSON.parse(JSON.stringify(this.parameters)),
       JSON.parse(JSON.stringify(this.headers)));
   },
 
-  toString: function(){
-    var header, parameter, idx, uri,
-      headers = [];
+  toRaw: function() {
+    return this._toString(this._raw);
+  },
 
-    uri  = this.scheme + ':';
+  toString: function() {
+    return this._toString(this._normal);
+  },
+
+  _toString: function(uri) {
+    var header, parameter, idx, uriString, headers = [];
+
+    uriString  = uri.scheme + ':';
     // add slashes if it's not a sip(s) URI
-    if (!this.scheme.match("^sips?$")) {
-      uri += "//";
+    if (!uri.scheme.toLowerCase().match("^sips?$")) {
+      uriString += "//";
     }
-    if (this.user) {
-      uri += SIP.Utils.escapeUser(this.user) + '@';
+    if (uri.user) {
+      uriString += SIP.Utils.escapeUser(uri.user) + '@';
     }
-    uri += this.host;
-    if (this.port || this.port === 0) {
-      uri += ':' + this.port;
+    uriString += uri.host;
+    if (uri.port || uri.port === 0) {
+      uriString += ':' + uri.port;
     }
 
     for (parameter in this.parameters) {
-      uri += ';' + parameter;
+      uriString += ';' + parameter;
 
       if (this.parameters[parameter] !== null) {
-        uri += '='+ this.parameters[parameter];
+        uriString += '='+ this.parameters[parameter];
       }
     }
 
@@ -178,10 +212,10 @@ URI.prototype = {
     }
 
     if (headers.length > 0) {
-      uri += '?' + headers.join('&');
+      uriString += '?' + headers.join('&');
     }
 
-    return uri;
+    return uriString;
   }
 };
 

--- a/test/spec/SpecURI.js
+++ b/test/spec/SpecURI.js
@@ -276,6 +276,11 @@ describe("URI", function() {
     expect(clonedURI.port).toEqual(URI.port);
     expect(clonedURI.parameters).toEqual(URI.parameters);
     expect(clonedURI.headers).toEqual(URI.headers);
+
+    expect(clonedURI._raw.scheme).toEqual(URI._raw.scheme);
+    expect(clonedURI._raw.user).toEqual(URI._raw.user);
+    expect(clonedURI._raw.host).toEqual(URI._raw.host);
+    expect(clonedURI._raw.port).toEqual(URI._raw.port);
   });
   
   it(".toString: be able to create a string of itself", function() {
@@ -348,6 +353,7 @@ describe("URI", function() {
     itsMethod('parses header X-HEADER-2', 'getHeader', 'X-HEADER-2', ['BbB']);
     itsMethod('doesn\'t parse missing header "nooo"', 'getHeader', 'nooo', undefined);
     itsMethod('correctly toString()s itself', 'toString', undefined, 'sip:aliCE@versatica.com:6060;transport=tcp;foo=abc;baz?X-Header-1=AaA1&X-Header-1=AAA2&X-Header-2=BbB');
+    itsMethod('correctly toRaw()s itself', 'toRaw', undefined, 'SIP:aliCE@versaTICA.Com:6060;transport=tcp;foo=abc;baz?X-Header-1=AaA1&X-Header-1=AAA2&X-Header-2=BbB');
 
     var newUser = 'Iñaki:PASSWD';
     describe('when setting the user to "' + newUser + '"', function () {


### PR DESCRIPTION
Implementation of outcome discussed on PR https://github.com/onsip/SIP.js/pull/188.

 * I moved the lowercasing out of `Grammar.pegjs` and into the `URI` constructor, so that it has access to the original string.
 * I created a `toRaw()` method that will create a string using the original (raw) values and plugged it in where appropriate. `toString()` is unaffected.
 * Added tests for the new functionality.