### PR TITLE
Timer B should be reset on provisional responses

### DIFF
--- a/src/Transactions.js
+++ b/src/Transactions.js
@@ -172,13 +172,18 @@ InviteClientTransaction.prototype.stateChanged = function(state) {
 };
 
 InviteClientTransaction.prototype.send = function() {
-  var tr = this;
   this.stateChanged(C.STATUS_CALLING);
-  this.B = SIP.Timers.setTimeout(tr.timer_B.bind(tr), SIP.Timers.TIMER_B);
+  this.resetTimerB();
 
   if(!this.transport.send(this.request)) {
     this.onTransportError();
   }
+};
+
+InviteClientTransaction.prototype.resetTimerB = function() {
+  var tr = this;
+  SIP.Timers.clearTimeout(this.B);
+  this.B = SIP.Timers.setTimeout(tr.timer_B.bind(tr), SIP.Timers.TIMER_B);
 };
 
 InviteClientTransaction.prototype.onTransportError = function() {
@@ -280,12 +285,14 @@ InviteClientTransaction.prototype.receiveResponse = function(response) {
     switch(this.state) {
       case C.STATUS_CALLING:
         this.stateChanged(C.STATUS_PROCEEDING);
+        this.resetTimerB();
         this.request_sender.receiveResponse(response);
         if(this.cancel) {
           this.transport.send(this.cancel);
         }
         break;
       case C.STATUS_PROCEEDING:
+        this.resetTimerB();
         this.request_sender.receiveResponse(response);
         break;
     }


### PR DESCRIPTION
When transitioning from CALLING to PROCEEDING and on every further provisional response, we should reset Timer B. Precedent is provided by Kamailio (http://kamailio.org/docs/modules/4.2.x/modules/tm.html#restart_fr_on_each_reply) and the use-case is for call queueing relying on 182 Queued status, which is periodically retransmitted while the call remains queued.