### PR TITLE
Allow setting additional Supported option tags

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -156,6 +156,45 @@ return {
     603: 'Decline',
     604: 'Does Not Exist Anywhere',
     606: 'Not Acceptable'
+  },
+
+  /* SIP Option Tags
+   * DOC: http://www.iana.org/assignments/sip-parameters/sip-parameters.xhtml#sip-parameters-4
+   */
+  OPTION_TAGS: {
+    '100rel':                   true,  // RFC 3262
+    199:                        true,  // RFC 6228
+    answermode:                 true,  // RFC 5373
+    'early-session':            true,  // RFC 3959
+    eventlist:                  true,  // RFC 4662
+    explicitsub:                true,  // RFC-ietf-sipcore-refer-explicit-subscription-03
+    'from-change':              true,  // RFC 4916
+    'geolocation-http':         true,  // RFC 6442
+    'geolocation-sip':          true,  // RFC 6442
+    gin:                        true,  // RFC 6140
+    gruu:                       true,  // RFC 5627
+    histinfo:                   true,  // RFC 7044
+    ice:                        true,  // RFC 5768
+    join:                       true,  // RFC 3911
+    'multiple-refer':           true,  // RFC 5368
+    norefersub:                 true,  // RFC 4488
+    nosub:                      true,  // RFC-ietf-sipcore-refer-explicit-subscription-03
+    outbound:                   true,  // RFC 5626
+    path:                       true,  // RFC 3327
+    policy:                     true,  // RFC 6794
+    precondition:               true,  // RFC 3312
+    pref:                       true,  // RFC 3840
+    privacy:                    true,  // RFC 3323
+    'recipient-list-invite':    true,  // RFC 5366
+    'recipient-list-message':   true,  // RFC 5365
+    'recipient-list-subscribe': true,  // RFC 5367
+    replaces:                   true,  // RFC 3891
+    'resource-priority':        true,  // RFC 4412
+    'sdp-anat':                 true,  // RFC 4092
+    'sec-agree':                true,  // RFC 3329
+    tdialog:                    true,  // RFC 4538
+    timer:                      true,  // RFC 4028
+    uui:                        true   // RFC 7433
   }
 };
 };

--- a/src/SIPMessage.js
+++ b/src/SIPMessage.js
@@ -33,9 +33,10 @@ function getSupportedHeader (request) {
   optionTags = optionTags.concat(request.ua.configuration.extraSupported);
 
   optionTags = optionTags.filter(function(optionTag) {
+    var registered = SIP.C.OPTION_TAGS[optionTag];
     var unique = !optionTagSet[optionTag];
     optionTagSet[optionTag] = true;
-    return unique;
+    return registered && unique;
   });
 
   return 'Supported: ' + optionTags.join(', ') + '\r\n';

--- a/src/SIPMessage.js
+++ b/src/SIPMessage.js
@@ -12,6 +12,7 @@ var
 
 function getSupportedHeader (request) {
   var optionTags = [];
+  var optionTagSet = {};
 
   if (request.method === SIP.C.REGISTER) {
     optionTags.push('path', 'gruu');
@@ -28,6 +29,14 @@ function getSupportedHeader (request) {
   }
 
   optionTags.push('outbound');
+
+  optionTags = optionTags.concat(request.ua.configuration.extraSupported);
+
+  optionTags = optionTags.filter(function(optionTag) {
+    var unique = !optionTagSet[optionTag];
+    optionTagSet[optionTag] = true;
+    return unique;
+  });
 
   return 'Supported: ' + optionTags.join(', ') + '\r\n';
 }

--- a/src/SIPMessage.js
+++ b/src/SIPMessage.js
@@ -11,6 +11,7 @@ var
   IncomingResponse;
 
 function getSupportedHeader (request) {
+  var allowUnregistered = request.ua.configuration.hackAllowUnregisteredOptionTags;
   var optionTags = [];
   var optionTagSet = {};
 
@@ -36,7 +37,7 @@ function getSupportedHeader (request) {
     var registered = SIP.C.OPTION_TAGS[optionTag];
     var unique = !optionTagSet[optionTag];
     optionTagSet[optionTag] = true;
-    return registered && unique;
+    return (registered || allowUnregistered) && unique;
   });
 
   return 'Supported: ' + optionTags.join(', ') + '\r\n';

--- a/src/UA.js
+++ b/src/UA.js
@@ -908,6 +908,7 @@ UA.prototype.loadConfig = function(configuration) {
       hackViaTcp: false,
       hackIpInContact: false,
       hackWssInTransport: false,
+      hackAllowUnregisteredOptionTags: false,
 
       contactTransport: 'ws',
       forceRport: false,
@@ -1139,6 +1140,7 @@ UA.configuration_skeleton = (function() {
       "hackViaTcp", // false.
       "hackIpInContact", //false
       "hackWssInTransport", //false
+      "hackAllowUnregisteredOptionTags", //false
       "contactTransport", // 'ws'
       "forceRport", // false
       "iceCheckingTimeout",
@@ -1333,6 +1335,12 @@ UA.configuration_check = {
     hackWssInTransport: function(hackWssInTransport) {
       if (typeof hackWssInTransport === 'boolean') {
         return hackWssInTransport;
+      }
+    },
+
+    hackAllowUnregisteredOptionTags: function(hackAllowUnregisteredOptionTags) {
+      if (typeof hackAllowUnregisteredOptionTags === 'boolean') {
+        return hackAllowUnregisteredOptionTags;
       }
     },
 

--- a/src/UA.js
+++ b/src/UA.js
@@ -888,6 +888,8 @@ UA.prototype.loadConfig = function(configuration) {
 
       keepAliveInterval: 0,
 
+      extraSupported: [],
+
       usePreloadedRoute: false,
 
       //string to be inserted into User-Agent request header
@@ -1132,6 +1134,7 @@ UA.configuration_skeleton = (function() {
       "connectionRecoveryMaxInterval",
       "connectionRecoveryMinInterval",
       "keepAliveInterval",
+      "extraSupported",
       "displayName",
       "hackViaTcp", // false.
       "hackIpInContact", //false
@@ -1369,6 +1372,23 @@ UA.configuration_check = {
           return value;
         }
       }
+    },
+
+    extraSupported: function(optionTags) {
+      var idx, length;
+
+      if (!(optionTags instanceof Array)) {
+        return;
+      }
+
+      length = optionTags.length;
+      for (idx = 0; idx < length; idx++) {
+        if (typeof optionTags[idx] !== 'string') {
+          return;
+        }
+      }
+
+      return optionTags;
     },
 
     noAnswerTimeout: function(noAnswerTimeout) {


### PR DESCRIPTION
It would be nice to be able to add Supported option tags in addition to those already set by SIP.js. This PR adds a new configuration option, `supported`, taking an array of option tags to append to the Supported header.

Open questions:
- This is as simple as possible—just concat the Arrays—but it also means that you could duplicate option tags, including those that SIP.js already sets (path, gruu, 100rel, replaces, outbound). Is this something that should be protected against (e.g., by using a Set)?
- The name `supported` might suggest the configuration option overwrites all the option tags that _would be_ set in the Supported header. Would it be more appropriate to name it, e.g., `extraSupportedOptionTags`?