### PR TITLE
Emit "notify" from Session

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -723,6 +723,7 @@ Session.prototype = {
         break;
       case SIP.C.NOTIFY:
         request.reply(200, 'OK');
+        this.emit('notify', request);
         break;
     }
   },


### PR DESCRIPTION
I see that some incoming requests (BYE, REFER) and all outgoing requests emit a corresponding event on the `Session`. Would you consider adding incoming NOTIFY?