### PR TITLE
WebRTC.MediaStreamManager - call MediaStreamTrack#stop instead of MediaStream#stop

### DIFF
--- a/src/WebRTC/MediaStreamManager.js
+++ b/src/WebRTC/MediaStreamManager.js
@@ -147,7 +147,9 @@ MediaStreamManager.prototype = Object.create(SIP.EventEmitter.prototype, {
     streams.forEach(function (stream) {
       var streamId = MediaStreamManager.streamId(stream);
       if (this.acquisitions[streamId] === false) {
-        stream.stop();
+        stream.getTracks().forEach(function (track) {
+          track.stop();
+        });
       }
       delete this.acquisitions[streamId];
     }, this);

--- a/test/helpers/HTML5.js
+++ b/test/helpers/HTML5.js
@@ -46,14 +46,21 @@
     }
   }
   getUserMedia.fakeStream = function () {
+    var audioTracks = [{
+      id: Math.random().toString(),
+      stop: jasmine.createSpy('stop'),
+    }];
+    var videoTracks = [];
     return {
-      getAudioTracks: function(id){
-        return [{
-          id: id
-        }];
-      }.bind(null, Math.random().toString()),
-      getVideoTracks: function(){return [];},
-      stop: jasmine.createSpy('stop')
+      getAudioTracks: function () {
+        return audioTracks;
+      },
+      getTracks: function () {
+        return audioTracks.concat(videoTracks);
+      },
+      getVideoTracks: function () {
+        return videoTracks;
+      },
     };
   };
   getUserMedia.orig = window.navigator.getUserMedia;

--- a/test/spec/MediaStreamManager.js
+++ b/test/spec/MediaStreamManager.js
@@ -129,9 +129,11 @@ describe('MediaStreamManager', function () {
       );
     });
 
-    it('calls stop() on the MediaStream it was passed', function () {
+    it('calls stop() on the tracks of the MediaStream it was passed', function () {
         expect(acquiredStream).not.toBeNull();
-        expect(acquiredStream.stop).toHaveBeenCalled();
+        acquiredStream.getTracks().forEach(function (track) {
+          expect(track.stop).toHaveBeenCalled();
+        });
     });
   });
 
@@ -169,11 +171,13 @@ describe('MediaStreamManager', function () {
         });
     });
 
-    it('.release does not stop the stream', function (done) {
+    it('.release does not stop the stream\'s tracks', function (done) {
       mediaStreamManager.acquire(mediaHint).then(onSuccess, onFailure)
       .then(function () {
         mediaStreamManager.release(stream);
-        expect(stream.stop).not.toHaveBeenCalled();
+        stream.getTracks().forEach(function (track) {
+          expect(track.stop).not.toHaveBeenCalled();
+        });
         done();
       });
     });


### PR DESCRIPTION
MediaStream.stop() is deprecated and will be removed in M47, around November 2015
    
see https://groups.google.com/d/msg/sip_js/t7Km0p11Jpk/rMmwJTCHAAAJ
