### PR TITLE
Include Content-Length on ACKs

### DIFF
--- a/src/Transactions.js
+++ b/src/Transactions.js
@@ -235,6 +235,7 @@ InviteClientTransaction.prototype.sendACK = function(response) {
   this.ack += 'To: ' + response.getHeader('to') + '\r\n';
   this.ack += 'From: ' + this.request.headers['From'].toString() + '\r\n';
   this.ack += 'Call-ID: ' + this.request.headers['Call-ID'].toString() + '\r\n';
+  this.ack += 'Content-Length: 0\r\n';
   this.ack += 'CSeq: ' + this.request.headers['CSeq'].toString().split(' ')[0];
   this.ack += ' ACK\r\n\r\n';
 


### PR DESCRIPTION
RFC3261 states (my emphasis):

> 20.14 Content-Length
>
>   The Content-Length header field indicates the size of the message-
>   body, in decimal number of octets, sent to the recipient.
>   Applications SHOULD use this field to indicate the size of the
>   message-body to be transferred, regardless of the media type of the
>   entity.  *If a stream-based protocol (such as TCP) is used as
>   transport, the header field MUST be used.*
>
>   The size of the message-body does not include the CRLF separating
>   header fields and body.  Any Content-Length greater than or equal to
>   zero is a valid value.  If no body is present in a message, then the
>   Content-Length header field value MUST be set to zero.
>
>   The ability to omit Content-Length simplifies the creation of
>   cgi-like scripts that dynamically generate responses.
>
>   The compact form of the header field is l.
>
>   Examples:
>
>      Content-Length: 349
>      l: 173

Some UAs (for example https://github.com/kalta/nksip) error on ACKs without a Content-Length.