### PR TITLE
Make Session SDP-agnostic

### DIFF
--- a/src/Hacks.js
+++ b/src/Hacks.js
@@ -14,10 +14,11 @@ SIP = SIP;
 
 var Hacks = {
   AllBrowsers: {
-    maskDtls: function (message) {
-      if (message.body) {
-        message.body = message.body.replace(/ UDP\/TLS\/RTP\/SAVP/gmi, " RTP/SAVP");
+    maskDtls: function (sdp) {
+      if (sdp) {
+        sdp = sdp.replace(/ UDP\/TLS\/RTP\/SAVP/gmi, " RTP/SAVP");
       }
+      return sdp;
     },
     unmaskDtls: function (sdp) {
       /**
@@ -40,10 +41,11 @@ var Hacks = {
       return typeof mozRTCPeerConnection !== 'undefined';
     },
 
-    cannotHandleExtraWhitespace: function (message) {
-      if (this.isFirefox() && message.body) {
-        message.body = message.body.replace(/ \r\n/g, "\r\n");
+    cannotHandleExtraWhitespace: function (sdp) {
+      if (this.isFirefox() && sdp) {
+        sdp = sdp.replace(/ \r\n/g, "\r\n");
       }
+      return sdp;
     },
 
     hasMissingCLineInSDP: function (sdp) {

--- a/src/MediaHandler.js
+++ b/src/MediaHandler.js
@@ -39,13 +39,13 @@ MediaHandler.prototype = Object.create(EventEmitter.prototype, {
   }},
 
   /**
-  * Message reception.
-  * @param {String} type
-  * @param {String} description
-  */
-  setDescription: {value: function setDescription (description) {
+   * Set the session description contained in a SIP message.
+   * @param {SIP.SIPMessage} message
+   * @returns {Promise}
+   */
+  setDescription: {value: function setDescription (message) {
     // keep jshint happy
-    description = description;
+    message = message;
   }}
 });
 

--- a/src/MediaHandler.js
+++ b/src/MediaHandler.js
@@ -29,6 +29,16 @@ MediaHandler.prototype = Object.create(EventEmitter.prototype, {
   }},
 
   /**
+   * Check if a SIP message contains a session description.
+   * @param {SIP.SIPMessage} message
+   * @returns {boolean}
+   */
+  hasDescription: {value: function hasDescription (message) {
+    // keep jshint happy
+    message = message;
+  }},
+
+  /**
   * Message reception.
   * @param {String} type
   * @param {String} description

--- a/src/Session.js
+++ b/src/Session.js
@@ -548,11 +548,7 @@ Session.prototype = {
   receiveReinvite: function(request) {
     var self = this;
 
-    if (!request.body) {
-      return;
-    }
-
-    if (request.getHeader('Content-Type') !== 'application/sdp') {
+    if (!this.mediaHandler.hasDescription(request)) {
       this.logger.warn('invalid Content-Type');
       request.reply(415);
       return;
@@ -714,8 +710,7 @@ Session.prototype = {
    * @private
    */
   receiveReinviteResponse: function(response) {
-    var self = this,
-        contentType = response.getHeader('Content-Type');
+    var self = this;
 
     if (this.status === C.STATUS_TERMINATED) {
       return;
@@ -729,10 +724,7 @@ Session.prototype = {
 
         this.sendRequest(SIP.C.ACK,{cseq:response.cseq});
 
-        if(!response.body) {
-          this.reinviteFailed();
-          break;
-        } else if (contentType !== 'application/sdp') {
+        if (!this.mediaHandler.hasDescription(response)) {
           this.reinviteFailed();
           break;
         }
@@ -969,18 +961,23 @@ InviteServerContext = function(ua, request) {
     contentType = request.getHeader('Content-Type'),
     contentDisp = request.parseHeader('Content-Disposition');
 
+  SIP.Utils.augment(this, SIP.ServerContext, [ua, request]);
+  SIP.Utils.augment(this, SIP.Session, [ua.configuration.mediaHandlerFactory]);
+
+  //Initialize Media Session
+  this.mediaHandler = this.mediaHandlerFactory(this, {
+    RTCConstraints: {"optional": [{'DtlsSrtpKeyAgreement': 'true'}]}
+  });
+
   // Check body and content type
-  if ((!contentDisp && contentType !== 'application/sdp') || (contentDisp && contentDisp.type === 'render')) {
+  if ((!contentDisp && !this.mediaHandler.hasDescription(request)) || (contentDisp && contentDisp.type === 'render')) {
     this.renderbody = request.body;
     this.rendertype = contentType;
-  } else if (contentType !== 'application/sdp' && (contentDisp && contentDisp.type === 'session')) {
+  } else if (!this.mediaHandler.hasDescription(request) && (contentDisp && contentDisp.type === 'session')) {
     request.reply(415);
     //TODO: instead of 415, pass off to the media handler, who can then decide if we can use it
     return;
   }
-
-  SIP.Utils.augment(this, SIP.ServerContext, [ua, request]);
-  SIP.Utils.augment(this, SIP.Session, [ua.configuration.mediaHandlerFactory]);
 
   this.status = C.STATUS_INVITE_RECEIVED;
   this.from_tag = request.from_tag;
@@ -1020,11 +1017,6 @@ InviteServerContext = function(ua, request) {
     return;
   }
 
-  //Initialize Media Session
-  this.mediaHandler = this.mediaHandlerFactory(this, {
-    RTCConstraints: {"optional": [{'DtlsSrtpKeyAgreement': 'true'}]}
-  });
-
   if (this.mediaHandler && this.mediaHandler.getRemoteStreams) {
     this.getRemoteStreams = this.mediaHandler.getRemoteStreams.bind(this.mediaHandler);
     this.getLocalStreams = this.mediaHandler.getLocalStreams.bind(this.mediaHandler);
@@ -1061,7 +1053,7 @@ InviteServerContext = function(ua, request) {
     self.emit('invite',request);
   }
 
-  if (!request.body || this.renderbody) {
+  if (!this.mediaHandler.hasDescription(request) || this.renderbody) {
     SIP.Timers.setTimeout(fireNewSession, 0);
   } else {
     this.hasOffer = true;
@@ -1469,7 +1461,7 @@ InviteServerContext.prototype = {
 
       // TODO - this logic assumes Content-Disposition defaults
       contentType = request.getHeader('Content-Type');
-      if (contentType !== 'application/sdp') {
+      if (!this.mediaHandler.hasDescription(request)) {
         this.renderbody = request.body;
         this.rendertype = contentType;
       }
@@ -1505,7 +1497,7 @@ InviteServerContext.prototype = {
     case SIP.C.ACK:
       if(this.status === C.STATUS_WAITING_FOR_ACK) {
         if (!this.hasAnswer) {
-          if(request.body && request.getHeader('content-type') === 'application/sdp') {
+          if(this.mediaHandler.hasDescription(request)) {
             // ACK contains answer to an INVITE w/o SDP negotiation
             this.hasAnswer = true;
             this.mediaHandler.setDescription(request.body)
@@ -1537,7 +1529,7 @@ InviteServerContext.prototype = {
       if (this.status === C.STATUS_WAITING_FOR_PRACK || this.status === C.STATUS_ANSWERED_WAITING_FOR_PRACK) {
         //localMedia = session.mediaHandler.localMedia;
         if(!this.hasAnswer) {
-          if(request.body && request.getHeader('content-type') === 'application/sdp') {
+          if(this.mediaHandler.hasDescription(request)) {
             this.hasAnswer = true;
             this.mediaHandler.setDescription(request.body)
             .then(
@@ -1899,7 +1891,7 @@ InviteClientContext.prototype = {
             return;
           }
 
-          if (!response.body) {
+          if (!this.mediaHandler.hasDescription(response)) {
             extraHeaders.push('RAck: ' + response.getHeader('rseq') + ' ' + response.getHeader('cseq'));
             this.earlyDialogs[id].pracked.push(response.getHeader('rseq'));
             this.earlyDialogs[id].sendRequest(this, SIP.C.PRACK, {
@@ -2039,7 +2031,7 @@ InviteClientContext.prototype = {
             }*/
             this.accepted(response);
           } else {
-            if(!response.body) {
+            if(!this.mediaHandler.hasDescription(response)) {
               this.acceptAndTerminate(response, 400, 'Missing session description');
               this.failed(response, SIP.C.causes.BAD_MEDIA_DESCRIPTION);
               break;
@@ -2093,7 +2085,7 @@ InviteClientContext.prototype = {
           }
           this.sendRequest(SIP.C.ACK, options);
         } else {
-          if(!response.body) {
+          if(!this.mediaHandler.hasDescription(response)) {
             this.acceptAndTerminate(response, 400, 'Missing session description');
             this.failed(response, SIP.C.causes.BAD_MEDIA_DESCRIPTION);
             break;

--- a/src/Session.js
+++ b/src/Session.js
@@ -998,10 +998,6 @@ InviteServerContext = function(ua, request) {
     return;
   }
 
-  //TODO: move this into media handler
-  SIP.Hacks.Firefox.cannotHandleExtraWhitespace(request);
-  SIP.Hacks.AllBrowsers.maskDtls(request);
-
   SIP.Utils.augment(this, SIP.ServerContext, [ua, request]);
   SIP.Utils.augment(this, SIP.Session, [ua.configuration.mediaHandlerFactory]);
 
@@ -1530,9 +1526,6 @@ InviteServerContext.prototype = {
         if (!this.hasAnswer) {
           if(request.body && request.getHeader('content-type') === 'application/sdp') {
             // ACK contains answer to an INVITE w/o SDP negotiation
-            SIP.Hacks.Firefox.cannotHandleExtraWhitespace(request);
-            SIP.Hacks.AllBrowsers.maskDtls(request);
-
             this.hasAnswer = true;
             this.mediaHandler.setDescription(request.body)
             .then(
@@ -1925,9 +1918,6 @@ InviteClientContext.prototype = {
             return;
           }
 
-          SIP.Hacks.Firefox.cannotHandleExtraWhitespace(response);
-          SIP.Hacks.AllBrowsers.maskDtls(response);
-
           if (!response.body) {
             extraHeaders.push('RAck: ' + response.getHeader('rseq') + ' ' + response.getHeader('cseq'));
             this.earlyDialogs[id].pracked.push(response.getHeader('rseq'));
@@ -2044,9 +2034,6 @@ InviteClientContext.prototype = {
           break;
         }
 
-        SIP.Hacks.Firefox.cannotHandleExtraWhitespace(response);
-        SIP.Hacks.AllBrowsers.maskDtls(response);
-
         // This is an invite without sdp
         if (!this.hasOffer) {
           if (this.earlyDialogs[id] && this.earlyDialogs[id].mediaHandler.localMedia) {
@@ -2087,8 +2074,6 @@ InviteClientContext.prototype = {
               if(session.isCanceled || session.status === C.STATUS_TERMINATED) {
                 return;
               }
-
-              sdp = SIP.Hacks.Firefox.hasMissingCLineInSDP(sdp);
 
               session.status = C.STATUS_CONFIRMED;
               session.hasAnswer = true;

--- a/src/Session.js
+++ b/src/Session.js
@@ -554,7 +554,7 @@ Session.prototype = {
       return;
     }
 
-    this.mediaHandler.setDescription(request.body)
+    this.mediaHandler.setDescription(request)
     .then(this.mediaHandler.getDescription.bind(this.mediaHandler, this.mediaHint))
     .then(function(body) {
       request.reply(200, null, ['Contact: ' + self.contact], body,
@@ -730,7 +730,7 @@ Session.prototype = {
         }
 
         //REVISIT
-        this.mediaHandler.setDescription(response.body)
+        this.mediaHandler.setDescription(response)
         .then(
           function onSuccess () {
             self.reinviteSucceeded();
@@ -1057,7 +1057,7 @@ InviteServerContext = function(ua, request) {
     SIP.Timers.setTimeout(fireNewSession, 0);
   } else {
     this.hasOffer = true;
-    this.mediaHandler.setDescription(request.body)
+    this.mediaHandler.setDescription(request)
     .then(
       fireNewSession,
       function onFailure (e) {
@@ -1500,7 +1500,7 @@ InviteServerContext.prototype = {
           if(this.mediaHandler.hasDescription(request)) {
             // ACK contains answer to an INVITE w/o SDP negotiation
             this.hasAnswer = true;
-            this.mediaHandler.setDescription(request.body)
+            this.mediaHandler.setDescription(request)
             .then(
               confirmSession.bind(this),
               function onFailure (e) {
@@ -1531,7 +1531,7 @@ InviteServerContext.prototype = {
         if(!this.hasAnswer) {
           if(this.mediaHandler.hasDescription(request)) {
             this.hasAnswer = true;
-            this.mediaHandler.setDescription(request.body)
+            this.mediaHandler.setDescription(request)
             .then(
               function onSuccess () {
                 SIP.Timers.clearTimeout(this.timers.rel1xxTimer);
@@ -1906,7 +1906,7 @@ InviteClientContext.prototype = {
             this.hasAnswer = true;
             this.dialog.pracked.push(response.getHeader('rseq'));
 
-            this.mediaHandler.setDescription(response.body)
+            this.mediaHandler.setDescription(response)
             .then(
               function onSuccess () {
                 extraHeaders.push('RAck: ' + response.getHeader('rseq') + ' ' + response.getHeader('cseq'));
@@ -1941,7 +1941,7 @@ InviteClientContext.prototype = {
 
             earlyDialog.pracked.push(response.getHeader('rseq'));
 
-            earlyMedia.setDescription(response.body)
+            earlyMedia.setDescription(response)
             .then(earlyMedia.getDescription.bind(earlyMedia, session.mediaHint))
             .then(function onSuccess(sdp) {
               extraHeaders.push('Content-Type: application/sdp');
@@ -2040,7 +2040,7 @@ InviteClientContext.prototype = {
               break;
             }
             this.hasOffer = true;
-            this.mediaHandler.setDescription(response.body)
+            this.mediaHandler.setDescription(response)
             .then(this.mediaHandler.getDescription.bind(this.mediaHandler, this.mediaHint))
             .then(function onSuccess(sdp) {
               //var localMedia;
@@ -2094,7 +2094,7 @@ InviteClientContext.prototype = {
             break;
           }
           this.hasAnswer = true;
-          this.mediaHandler.setDescription(response.body)
+          this.mediaHandler.setDescription(response)
           .then(
             function onSuccess () {
               var options = {};//,localMedia;

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -488,6 +488,14 @@ Utils= {
     var temp = WordToHex(a)+WordToHex(b)+WordToHex(c)+WordToHex(d);
 
     return temp.toLowerCase();
+  },
+
+  getDescriptionHeaders: function(description) {
+    var headers = ['Content-Type: ' + description.contentType];
+    if (description.extraHeaders) {
+      headers = headers.concat(description.extraHeaders);
+    }
+    return headers;
   }
 };
 

--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -134,6 +134,10 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
         self.render();
         return self.createOfferOrAnswer(self.RTCConstraints);
       })
+      .then(function(sdp) {
+        sdp = SIP.Hacks.Firefox.hasMissingCLineInSDP(sdp);
+        return sdp;
+      })
     ;
   }},
 
@@ -143,6 +147,9 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
   * @param {String} sdp
   */
   setDescription: {writable: true, value: function setDescription (sdp) {
+    sdp = SIP.Hacks.Firefox.cannotHandleExtraWhitespace(sdp);
+    sdp = SIP.Hacks.AllBrowsers.maskDtls(sdp);
+
     var rawDescription = {
       type: this.hasOffer('local') ? 'answer' : 'offer',
       sdp: sdp

--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -165,11 +165,13 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
   }},
 
   /**
-  * Message reception.
-  * @param {String} type
-  * @param {String} sdp
-  */
-  setDescription: {writable: true, value: function setDescription (sdp) {
+   * Set the session description contained in a SIP message.
+   * @param {SIP.SIPMessage} message
+   * @returns {Promise}
+   */
+  setDescription: {writable: true, value: function setDescription (message) {
+    var sdp = message.body;
+
     this.remote_hold = /a=(sendonly|inactive)/.test(sdp);
 
     sdp = SIP.Hacks.Firefox.cannotHandleExtraWhitespace(sdp);

--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -156,6 +156,15 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
   }},
 
   /**
+   * Check if a SIP message contains a session description.
+   * @param {SIP.SIPMessage} message
+   * @returns {boolean}
+   */
+  hasDescription: {writeable: true, value: function hasDescription (message) {
+    return message.getHeader('Content-Type') === 'application/sdp' && !!message.body;
+  }},
+
+  /**
   * Message reception.
   * @param {String} type
   * @param {String} sdp

--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -150,7 +150,10 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
           }
         }
 
-        return sdp;
+        return {
+          body: sdp,
+          contentType: 'application/sdp'
+        };
       })
     ;
   }},

--- a/test/helpers/rps.js
+++ b/test/helpers/rps.js
@@ -67,6 +67,10 @@ RPSMediaHandler.prototype = {
     }.bind(this), 0);
   },
 
+  hasDescription: function (message) {
+    return true;
+  },
+
   setDescription: function (description, onSuccess, onFailure) {
         /*
      * Here, we receive the description of the remote end's offer/answer.

--- a/test/helpers/rps.js
+++ b/test/helpers/rps.js
@@ -63,7 +63,7 @@ RPSMediaHandler.prototype = {
     // Provide a description to the session using the callbacks.
     this.timeout = setTimeout(function () {
       delete this.timeout;
-      onSuccess(this.myGesture);
+      onSuccess({ body: this.myGesture, contentType: 'text/plain' });
     }.bind(this), 0);
   },
 

--- a/test/helpers/rps.js
+++ b/test/helpers/rps.js
@@ -71,7 +71,7 @@ RPSMediaHandler.prototype = {
     return true;
   },
 
-  setDescription: function (description, onSuccess, onFailure) {
+  setDescription: function (message, onSuccess, onFailure) {
         /*
      * Here, we receive the description of the remote end's offer/answer.
      * In normal WebRTC calls, this would be an RTCSessionDescription with
@@ -82,6 +82,7 @@ RPSMediaHandler.prototype = {
      * String gesture indication the other end chose.
      */
     // Set their gesture based on the remote description
+    var description = message.body;
     if (['rock', 'paper', 'scissors'].indexOf(description) < 0) {
       this.timeout = setTimeout(function () {
         delete this.timeout;

--- a/test/spec/InviteServerContext.js
+++ b/test/spec/InviteServerContext.js
@@ -17,8 +17,11 @@ describe('A UAS receiving an INVITE', function () {
         register: false,
         mediaHandlerFactory: function () {
           return {
-            getDescription: function () {},
-            setDescription: function () {}
+            getDescription: function () { return SIP.Utils.Promise.resolve('foo'); },
+            hasDescription: function (message) {
+              return message.getHeader('Content-Type') === 'application/sdp' && !!message.body;
+            },
+            setDescription: function () { return SIP.Utils.Promise.resolve(); }
           };
         }
       };
@@ -53,7 +56,16 @@ describe('A UAS receiving an INVITE', function () {
     beforeEach(function (done) {
       ua_config = {
         uri: 'alice@example.com',
-        register: false
+        register: false,
+        mediaHandlerFactory: function () {
+          return {
+            getDescription: function () { return SIP.Utils.Promise.resolve('foo'); },
+            hasDescription: function (message) {
+              return message.getHeader('Content-Type') === 'application/sdp' && !!message.body;
+            } ,
+            setDescription: function () { return SIP.Utils.Promise.resolve(); }
+          };
+        }
       };
 
       ua = new SIP.UA(ua_config).once('connected', function () {
@@ -95,7 +107,16 @@ describe('A UAS receiving an INVITE', function () {
     beforeEach(function (done) {
       ua_config = {
         uri: 'alice@example.com',
-        register: false
+        register: false,
+        mediaHandlerFactory: function () {
+          return {
+            getDescription: function () { return SIP.Utils.Promise.resolve('foo'); },
+            hasDescription: function (message) {
+              return message.getHeader('Content-Type') === 'application/sdp' && !!message.body;
+            },
+            setDescription: function () { return SIP.Utils.Promise.resolve(); }
+          };
+        }
       };
 
       ua = new SIP.UA(ua_config).once('connected', function () {
@@ -149,7 +170,16 @@ describe('A UAS receiving an INVITE', function () {
     beforeEach(function (done) {
       ua_config = {
         uri: 'alice@example.com',
-        register: false
+        register: false,
+        mediaHandlerFactory: function () {
+          return {
+            getDescription: function () { return SIP.Utils.Promise.resolve('foo'); },
+            hasDescription: function (message) {
+              return message.getHeader('Content-Type') === 'application/sdp' && !!message.body;
+            },
+            setDescription: function () { return SIP.Utils.Promise.resolve(); }
+          };
+        }
       };
 
       ua = new SIP.UA(ua_config).once('connected', function () {

--- a/test/spec/SpecDialogs.js
+++ b/test/spec/SpecDialogs.js
@@ -4,7 +4,10 @@ describe('Dialogs', function() {
   var Dialog;
 
   beforeEach(function() {
-    var ua = new SIP.UA({uri: 'alice@example.com', wsServers: 'ws:server.example.com'});
+    var ua = new SIP.UA({
+      uri: 'alice@example.com',
+      wsServers: 'ws:server.example.com'
+    });
     ua.transport = jasmine.createSpyObj('transport', ['disconnect', 'send']);
     message = SIP.Parser.parseMessage([
       'INVITE sip:gled5gsn@hk95bautgaa7.invalid;transport=ws;aor=james%40onsnip.onsip.com SIP/2.0',

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -466,8 +466,11 @@ describe('Session', function() {
     beforeEach(function() {
       spyOn(Session, 'emit');
       Session.mediaHandler = {
-        setDescription: jasmine.createSpy('setDescription').and.returnValue(SIP.Utils.Promise.resolve(true)),
-        getDescription: jasmine.createSpy('getDescription').and.returnValue(SIP.Utils.Promise.resolve(true))
+        getDescription: jasmine.createSpy('getDescription').and.returnValue(SIP.Utils.Promise.resolve(true)),
+        hasDescription: function(message) {
+          return message.getHeader('Content-Type') === 'application/sdp' && !!message.body;
+        },
+        setDescription: jasmine.createSpy('setDescription').and.returnValue(SIP.Utils.Promise.resolve(true))
       };
     });
 
@@ -511,7 +514,12 @@ describe('Session', function() {
 
       spyOn(Session, 'sendRequest');
 
-      Session.mediaHandler = {setDescription: jasmine.createSpy('setDescription').and.returnValue(SIP.Utils.Promise.resolve(true))};
+      Session.mediaHandler = {
+        hasDescription: function(message) {
+          return message.getHeader('Content-Type') === 'application/sdp' && !!message.body;
+        },
+        setDescription: jasmine.createSpy('setDescription').and.returnValue(SIP.Utils.Promise.resolve(true))
+      };
     });
 
     it('returns without calling sendRequest or reinviteFailed when status is terminated', function() {
@@ -1219,6 +1227,7 @@ describe('InviteServerContext', function() {
       InviteServerContext.status = 4;
 
       spyOn(InviteServerContext.mediaHandler, 'getDescription').and.returnValue(SIP.Utils.Promise.resolve(true));
+      spyOn(InviteServerContext.mediaHandler, 'hasDescription').and.returnValue(true);
     });
 
     it('changes status to ANSWERED_WAITING_FOR_PRACK and returns this if status is WAITING_FOR_PRACK', function() {
@@ -1831,7 +1840,7 @@ describe('InviteClientContext', function() {
       expect(InviteClientContext.ua.sessions[InviteClientContext.id]).toBe(InviteClientContext);
     });
 
-    it('calls mediaHandler.getDescription async and returns this on success', function() {
+    it('calls mediaHandler.getDescription async and returns this on success', function(done) {
       var callback, s;
 
       spyOn(SIP.WebRTC, 'getUserMedia').and.callThrough();
@@ -2144,7 +2153,8 @@ describe('InviteClientContext', function() {
           'a= sendrecv',
           ''].join('\r\n'), ua);
 
-        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['setDescription', 'close']);
+        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['hasDescription', 'setDescription', 'close']);
+        InviteClientContext.mediaHandler.hasDescription.and.returnValue(true);
         InviteClientContext.mediaHandler.setDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
 
         InviteClientContext.hasOffer = true;
@@ -2264,9 +2274,10 @@ describe('InviteClientContext', function() {
 
       it('calls mediaHandler.setDescription if the request had no body and the response had no early dialog with media connected to it', function() {
         InviteClientContext.request.body = null;
-        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['setDescription', 'getDescription', 'close']);
-        InviteClientContext.mediaHandler.setDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
+        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['close', 'getDescription', 'hasDescription', 'setDescription']);
+        InviteClientContext.mediaHandler.hasDescription.and.returnValue(true);
         InviteClientContext.mediaHandler.getDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
+        InviteClientContext.mediaHandler.setDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
 
         InviteClientContext.receiveInviteResponse(response);
 
@@ -2275,7 +2286,8 @@ describe('InviteClientContext', function() {
 
       it('same as above, but does not make the call if the createDialog fails', function() {
         InviteClientContext.request.body = null;
-        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['setDescription', 'close']);
+        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['close', 'hasDescription', 'setDescription']);
+        InviteClientContext.mediaHandler.hasDescription.and.returnValue(true);
         InviteClientContext.mediaHandler.setDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
         spyOn(InviteClientContext, 'createDialog').and.returnValue(false);
 
@@ -2285,9 +2297,10 @@ describe('InviteClientContext', function() {
       });
 
       it('calls mediaHandler.setDescription if the request has a body', function() {
-        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['setDescription', 'getDescription', 'close']);
-        InviteClientContext.mediaHandler.setDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
+        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['close', 'getDescription', 'hasDescription', 'setDescription']);
         InviteClientContext.mediaHandler.getDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
+        InviteClientContext.mediaHandler.hasDescription.and.returnValue(true);
+        InviteClientContext.mediaHandler.setDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
 
         InviteClientContext.receiveInviteResponse(response);
 
@@ -2295,7 +2308,8 @@ describe('InviteClientContext', function() {
       });
 
       it('same as above, but does not make the call if the createDialog fails', function() {
-        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['setDescription', 'close']);
+        InviteClientContext.mediaHandler = jasmine.createSpyObj('mediaHandler', ['close', 'getDescription', 'hasDescription', 'setDescription']);
+        InviteClientContext.mediaHandler.hasDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
         InviteClientContext.mediaHandler.setDescription.and.returnValue(SIP.Utils.Promise.resolve(true));
         spyOn(InviteClientContext, 'createDialog').and.returnValue(false);
 

--- a/test/spec/WebRTC.MediaHandler.js
+++ b/test/spec/WebRTC.MediaHandler.js
@@ -298,10 +298,10 @@ describe('WebRTC.MediaHandler', function() {
     it('emits setDescription before creating RTCSessionDescription', function () {
       spyOn(SIP.WebRTC, 'RTCSessionDescription');
 
-      var mySDP = 'foo';
+      var mySDP = { body: 'foo' };
 
       var onSetDescription = jasmine.createSpy().and.callFake(function (raw) {
-        expect(raw.sdp).toEqual(mySDP);
+        expect(raw.sdp).toEqual(mySDP.body);
         expect(SIP.WebRTC.RTCSessionDescription).not.toHaveBeenCalled();
       });
       MediaHandler.on('setDescription', onSetDescription);


### PR DESCRIPTION
I have a use case where I need to be prepared to send and receive offers and answers in "multipart/mixed" messages. This use case may be too specific for SIP.js, so I looked at enabling it in a custom `MediaHandler`. Following up on #166, this PR includes changes that
- Move SDP hacks into `WebRTC/MediaHandler`.
- Expose an `onhold` property on `WebRTC/MediaHandler`—this is used in `Session` instead of matching a `RegExp` on the SDP.
- Remove SDP mangling from `sendReinvite`—now `WebRTC/MediaHandler` will check an `onhold` property in order to determine if it should rewrite the SDP in `getDescription`.
- Remove Content-Type checking from `Session`—now `Session` will pass the entire `SIPMessage` to `MediaHandler.hasDescription` (which can check its Content-Type, check if it has an empty `body`, or anything else).
- Pass the entire `SIPMessage` to `MediaHandler.setDescription`—for example, a `MediaHandler` expecting "multipart/mixed" messages needs to query the Content-Type in order to parse the `body`. There may be other `MediaHandler`s that observe other headers.
- Allow `MediaHandler.getDescription` to specify `extraHeaders` and `body`—for example, a `MediaHandler` could specify a Content-Type other than "application/sdp".

These are significant changes, and I only have the Jasmine tests passing (I have not yet tested with my application), but would you consider such a refactor?
