### PR TITLE
Resolves onsip/SIP.js#232

### DIFF
--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -240,6 +240,8 @@ SIP.Subscription.prototype = {
           switch (sub_state.reason) {
             case 'deactivated':
             case 'timeout':
+              this.terminateDialog();
+              this.request = new SIP.OutgoingRequest(this.method, this.request.to.uri.toString(), this.ua, null, this.extraHeaders.slice());
               this.subscribe();
               return;
             case 'probation':

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -96,6 +96,7 @@ SIP.Subscription.prototype = {
       }
 
       if (expires && expires <= this.expires) {
+        this.expires = expires;
         this.timers.sub_duration = SIP.Timers.setTimeout(sub.refresh.bind(sub), expires * 900);
       } else {
         if (!expires) {
@@ -198,12 +199,14 @@ SIP.Subscription.prototype = {
     var sub_state, sub = this;
 
     function setExpiresTimeout() {
+      var expires;
       if (sub_state.expires) {
         sub_state.expires = Math.min(sub.expires,
                                      Math.max(sub_state.expires, 0));
-        sub.timers.sub_duration = SIP.Timers.setTimeout(sub.refresh.bind(sub),
-                                                    sub_state.expires * 900);
+      } else {
+        expires = sub.expires;
       }
+      sub.timers.sub_duration = SIP.Timers.setTimeout(sub.refresh.bind(sub), expires * 900);
     }
 
     if (!this.matchEvent(request)) { //checks event and subscription_state headers


### PR DESCRIPTION
Refresh subscriptions even if the NOTIFY requests do not contain `expires` param in the `Subscription-State` header.