### PR TITLE
Resolves onsip/SIP.js#234

### DIFF
--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -237,6 +237,8 @@ SIP.Subscription.prototype = {
           switch (sub_state.reason) {
             case 'deactivated':
             case 'timeout':
+              this.terminateDialog();
+              this.request = new SIP.OutgoingRequest(this.method, this.request.to.uri.toString(), this.ua, null, this.extraHeaders.slice());
               this.subscribe();
               return;
             case 'probation':


### PR DESCRIPTION
The first line ensures that the dialog is terminated.
The second line prepares the new request, which will have a new Call-ID and new from tag.