### PR TITLE
 Resolves onsip/SIP.js#232, alternative fix to 861a6af 

### DIFF
--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -232,6 +232,7 @@ SIP.Subscription.prototype = {
         this.state = 'pending';
         break;
       case 'terminated':
+        SIP.Timers.clearTimeout(this.timers.sub_duration);
         if (sub_state.reason) {
           this.logger.log('terminating subscription with reason '+ sub_state.reason);
           switch (sub_state.reason) {

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -96,6 +96,8 @@ SIP.Subscription.prototype = {
       }
 
       if (expires && expires <= this.expires) {
+        // Preserve new expires value for subsequent requests
+        this.expires = expires;
         this.timers.sub_duration = SIP.Timers.setTimeout(sub.refresh.bind(sub), expires * 900);
       } else {
         if (!expires) {

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -199,6 +199,7 @@ SIP.Subscription.prototype = {
 
     function setExpiresTimeout() {
       if (sub_state.expires) {
+        SIP.Timers.clearTimeout(sub.timers.sub_duration);
         sub_state.expires = Math.min(sub.expires,
                                      Math.max(sub_state.expires, 0));
         sub.timers.sub_duration = SIP.Timers.setTimeout(sub.refresh.bind(sub),
@@ -216,7 +217,6 @@ SIP.Subscription.prototype = {
     request.reply(200, SIP.C.REASON_200);
 
     SIP.Timers.clearTimeout(this.timers.N);
-    SIP.Timers.clearTimeout(this.timers.sub_duration);
 
     this.emit('notify', {request: request});
 


### PR DESCRIPTION
Before, the refresh timeout was removed on each NOTIFY.

Now, the subscription timeout is only removed if the NOTIFY provides an Expires value, or if the request is terminated.

Also when the server provides a shorter Expires time in the response, this value is kept for subsequent requests.

