### PR TITLE
Force turnServers.urls into an array

### DIFF
--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -51,6 +51,9 @@ var MediaHandler = function(session, options) {
   length = turnServers.length;
   for (idx = 0; idx < length; idx++) {
     server = turnServers[idx];
+    if (Object.prototype.toString.call(server.urls) !== '[object Array]') {
+      server.urls = [].concat(server.urls);
+    } 
     for (jdx = 0; jdx < server.urls.length; jdx++) {
       servers.push({
         'url': server.urls[jdx],


### PR DESCRIPTION
If a single server is given a string can be used which must here be forced into an array.