### PR TITLE
Add hackReinviteErrorCode UA option

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -593,7 +593,11 @@ Session.prototype = {
     })
     .catch(function onFailure (e) {
       var statusCode;
-      if (e instanceof SIP.Exceptions.GetDescriptionError) {
+      if (self.ua.configuration.hackReinviteErrorCode) {
+        self.logger.error(e);
+        self.logger.error('overriding error code');
+        statusCode = self.ua.configuration.hackReinviteErrorCode;
+      } else if (e instanceof SIP.Exceptions.GetDescriptionError) {
         statusCode = 500;
       } else {
         self.logger.error(e);

--- a/src/UA.js
+++ b/src/UA.js
@@ -909,6 +909,7 @@ UA.prototype.loadConfig = function(configuration) {
       hackIpInContact: false,
       hackWssInTransport: false,
       hackAllowUnregisteredOptionTags: false,
+      hackReinviteErrorCode: 0,
 
       contactTransport: 'ws',
       forceRport: false,
@@ -1141,6 +1142,7 @@ UA.configuration_skeleton = (function() {
       "hackIpInContact", //false
       "hackWssInTransport", //false
       "hackAllowUnregisteredOptionTags", //false
+      "hackReinviteErrorCode", //0
       "contactTransport", // 'ws'
       "forceRport", // false
       "iceCheckingTimeout",
@@ -1338,6 +1340,12 @@ UA.configuration_check = {
     hackAllowUnregisteredOptionTags: function(hackAllowUnregisteredOptionTags) {
       if (typeof hackAllowUnregisteredOptionTags === 'boolean') {
         return hackAllowUnregisteredOptionTags;
+      }
+    },
+
+    hackReinviteErrorCode: function(hackReinviteErrorCode) {
+      if (typeof hackReinviteErrorCode === 'number') {
+        return hackReinviteErrorCode;
       }
     },
 


### PR DESCRIPTION
This allows issues like https://github.com/onsip/SIP.js/issues/258 to be
worked around by adding the following line to the UA configuration:

      hackReinviteErrorCode: 488,

(@lylepratt, could you confirm that this works for you?)