### PR TITLE
RegisterContext: Use UA displayName in To header

### DIFF
--- a/src/RegisterContext.js
+++ b/src/RegisterContext.js
@@ -26,6 +26,7 @@ RegisterContext = function (ua) {
   this.to_uri = ua.configuration.uri;
 
   params.to_uri = this.to_uri;
+  params.to_displayName = ua.configuration.displayName;
   params.call_id = this.call_id;
   params.cseq = this.cseq;
 


### PR DESCRIPTION
This can be tested by running the following code and examining the
output:

    var SIP = require('./');
    var ua = new SIP.UA({
      traceSip: true,
      displayName: 'XXX this should be in the REGISTER To header',
      uri: 'issue268@sipjs.onsip.com',
    });

See https://github.com/onsip/SIP.js/issues/268#issuecomment-170958998

Fixes https://github.com/onsip/SIP.js/issues/268