### PR TITLE
Do not require local streams.

### DIFF
--- a/src/WebRTC/MediaStreamManager.js
+++ b/src/WebRTC/MediaStreamManager.js
@@ -129,13 +129,18 @@ MediaStreamManager.prototype = Object.create(SIP.EventEmitter.prototype, {
           return callback.apply(null, callbackArgs);
         }.bind(this);
 
-        deferred.resolve(
-          SIP.WebRTC.getUserMedia(constraints)
-          .then(
-            emitThenCall.bind(this, 'userMedia', saveSuccess.bind(null, false)),
-            emitThenCall.bind(this, 'userMediaFailed', function(e){throw e;})
-          )
-        );
+        if (constraints.audio || constraints.video) {
+          deferred.resolve(
+            SIP.WebRTC.getUserMedia(constraints)
+            .then(
+              emitThenCall.bind(this, 'userMedia', saveSuccess.bind(null, false)),
+              emitThenCall.bind(this, 'userMediaFailed', function(e){throw e;})
+            )
+          );
+        } else {
+          // Local streams were explicitly excluded.
+          deferred.resolve([]);
+        }
       }.bind(this), 0);
 
       return deferred.promise;

--- a/test/spec/MediaStreamManager.js
+++ b/test/spec/MediaStreamManager.js
@@ -109,6 +109,32 @@ describe('MediaStreamManager', function () {
         done();
       });
     });
+
+    it('does not require local streams', function(done) {
+      var success, failure, onUM, onUMF;
+
+      success = jasmine.createSpy('success');
+      failure = jasmine.createSpy('failure');
+      onUM = jasmine.createSpy('userMediaFailed');
+      onUMF = jasmine.createSpy('userMediaFailed');
+
+      mediaStreamManager.on('userMedia', onUM);
+      mediaStreamManager.on('userMediaFailed', onUMF);
+
+      mediaStreamManager.acquire({
+        constraints: {
+          audio: false,
+          video: false
+        }
+      }).then(success, failure)
+      .then(function () {
+        expect(onUM).not.toHaveBeenCalled();
+        expect(onUMF).not.toHaveBeenCalled();
+        expect(success).toHaveBeenCalledWith([]);
+        expect(failure).not.toHaveBeenCalled();
+        done();
+      });
+    });
   });
 
   describe('.release', function () {


### PR DESCRIPTION
Use following media constraints to avoid getUserMedia call:

{video: false, audio: false}

Should be used in conjunction with mediaHandler.RTCConstraints of offerToReceiveAudio/Video.

Fixes https://github.com/onsip/SIP.js/issues/272