### PR TITLE
Exclude tests from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules/
 dist/sip*
 .grunt
 _SpecRunner.html
+test/


### PR DESCRIPTION
They aren't needed there, and removing them cuts package download size
by over a third (from 148K to 92K). Compare the output of the following
command before/after this change:

    rm sip.js-0.7.3.tgz; npm pack && du -sh sip.js-0.7.3.tgz