### PR TITLE
Update ws dependency to 1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "0.10"
+  - "0.12"
   - "4.2"
   - "stable"
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pegjs": "^0.8.0"
   },
   "engines": {
-    "node": ">=0.8"
+    "node": ">=0.12"
   },
   "license": "MIT",
   "scripts": {
@@ -50,7 +50,7 @@
     "test": "grunt travis --verbose"
   },
   "dependencies": {
-    "ws": "^0.6.4"
+    "ws": "^1.0.1"
   },
   "optionalDependencies": {
     "promiscuous": "^0.6.0"


### PR DESCRIPTION
Note: this drops support for node < 0.12, so travis and package.json adjusted as well

This is a pretty big change, as several versions of node support are dropped, but keeping up with the ws dependency is most likely good in the long run.

This is yet to be tested, but testing will begin today.