### PR TITLE
Session emits "statusChanged" events

### DIFF
--- a/src/Transactions.js
+++ b/src/Transactions.js
@@ -649,7 +649,7 @@ var checkTransaction = function(ua, request) {
         if(tr.state === C.STATUS_ACCEPTED) {
           return false;
         } else if(tr.state === C.STATUS_COMPLETED) {
-          tr.state = C.STATUS_CONFIRMED;
+          tr.stateChanged(C.STATUS_CONFIRMED);
           tr.I = SIP.Timers.setTimeout(tr.timer_I.bind(tr), SIP.Timers.TIMER_I);
           return true;
         }

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -1089,14 +1089,14 @@ describe('InviteServerContext', function() {
 
     jasmine.clock().tick(100);
 
-    expect(ISC.emit.calls.argsFor(2)[0]).toBe('progress');
+    expect(ISC.emit.calls.argsFor(4)[0]).toBe('progress');
 
     expect(ISC.status).toBe(4);
 
     expect(ISC.timers.userNoAnswerTimer).toBeDefined();
     expect(ISC.timers.expiresTimer).toBeDefined();
 
-    expect(ISC.emit.calls.argsFor(3)[0]).toBe('invite');
+    expect(ISC.emit.calls.argsFor(6)[0]).toBe('invite');
 
     jasmine.clock().uninstall();
   });


### PR DESCRIPTION
Hi SIP.js Team,

Currently, Transaction updates its `state` property via a `stateChanged` method which also emits a
"stateChanged" event. Would you consider a similar pattern for Session's `status` property?

This PR would add a `statusChanged` method to Session: all updates to `status` would be made through this method, and it would also emit a "statusChanged" event.

Thanks,
Mark