### PR TITLE
Get global WebSocket on an on-demand basis

### DIFF
--- a/src/SIP.js
+++ b/src/SIP.js
@@ -23,7 +23,7 @@ SIP.EventEmitter = require('./EventEmitter')(environment.console);
 SIP.C = require('./Constants')(SIP.name, SIP.version);
 SIP.Exceptions = require('./Exceptions');
 SIP.Timers = require('./Timers')(environment.timers);
-SIP.Transport = environment.Transport(SIP, environment.WebSocket);
+SIP.Transport = environment.Transport(SIP, environment);
 require('./Parser')(SIP);
 require('./SIPMessage')(SIP);
 require('./URI')(SIP);

--- a/src/Transport.js
+++ b/src/Transport.js
@@ -9,7 +9,7 @@
  * @param {SIP.UA} ua
  * @param {Object} server ws_server Object
  */
-module.exports = function (SIP, WebSocket) {
+module.exports = function (SIP, environment) {
 var Transport,
   C = {
     // Transport status codes
@@ -59,7 +59,7 @@ Transport.prototype = {
   send: function(msg) {
     var message = msg.toString();
 
-    if(this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if(this.ws && this.ws.readyState === environment.WebSocket.OPEN) {
       if (this.ua.configuration.traceSip === true) {
         this.logger.log('sending WebSocket message:\n\n' + message + '\n');
       }
@@ -143,7 +143,7 @@ Transport.prototype = {
   connect: function() {
     var transport = this;
 
-    if(this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+    if(this.ws && (this.ws.readyState === environment.WebSocket.OPEN || this.ws.readyState === environment.WebSocket.CONNECTING)) {
       this.logger.log('WebSocket ' + this.server.ws_uri + ' is already connected');
       return false;
     }
@@ -157,7 +157,7 @@ Transport.prototype = {
       (this.reconnection_attempts === 0)?1:this.reconnection_attempts);
 
     try {
-      this.ws = new WebSocket(this.server.ws_uri, 'sip');
+      this.ws = new environment.WebSocket(this.server.ws_uri, 'sip');
     } catch(e) {
       this.logger.warn('error connecting to WebSocket ' + this.server.ws_uri + ': ' + e);
     }

--- a/src/environment_browser.js
+++ b/src/environment_browser.js
@@ -17,7 +17,6 @@ function getPrefixedProperty (object, name) {
 }
 
 module.exports = {
-  WebSocket: toplevel.WebSocket,
   Transport: require('./Transport'),
   open: toplevel.open,
   Promise: toplevel.Promise,
@@ -43,3 +42,9 @@ module.exports = {
   createObjectURL: toplevel.URL && toplevel.URL.createObjectURL,
   revokeObjectURL: toplevel.URL && toplevel.URL.revokeObjectURL
 };
+
+Object.defineProperty(module.exports, 'WebSocket', {
+  get: function () {
+    return toplevel.WebSocket;
+  }
+});


### PR DESCRIPTION
This makes it easier to use sip.js with a WebSocket implementation that
defines itself after sip.js has loaded (for example, one provided by a
Cordova plugin).

This should resolve https://github.com/onsip/SIP.js/issues/240. @lylepratt, could you verify that it works for you?