### PR TITLE
Updates deprecated iceServer preparation.

### DIFF
--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -337,39 +337,23 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
   }},
 
   prepareIceServers: {writable: true, value: function prepareIceServers (stunServers, turnServers) {
-    var idx, jdx, length, server,
-      servers = [],
+    var servers = [],
       config = this.session.ua.configuration;
 
-    stunServers = stunServers || null;
-    turnServers = turnServers || null;
+    stunServers = stunServers || config.stunServers;
+    turnServers = turnServers || config.turnServers;
 
-    if (!stunServers) {
-      stunServers = config.stunServers;
-    }
-
-    if(!turnServers) {
-      turnServers = config.turnServers;
-    }
-
-    /* Change 'url' to 'urls' whenever this issue is solved:
-     * https://code.google.com/p/webrtc/issues/detail?id=2096
-     */
     [].concat(stunServers).forEach(function (server) {
-      servers.push({'url': server});
+      servers.push({'urls': server});
     });
 
-    length = turnServers.length;
-    for (idx = 0; idx < length; idx++) {
-      server = turnServers[idx];
-      for (jdx = 0; jdx < server.urls.length; jdx++) {
-        servers.push({
-          'url': server.urls[jdx],
-          'username': server.username,
-          'credential': server.password
-        });
-      }
-    }
+    [].concat(turnServers).forEach(function (server) {
+      servers.push({
+        'urls': server.urls,
+        'username': server.username,
+        'credential': server.password
+      });
+    });
 
     return servers;
   }},

--- a/test/spec/WebRTC.MediaHandler.js
+++ b/test/spec/WebRTC.MediaHandler.js
@@ -335,4 +335,39 @@ describe('WebRTC.MediaHandler', function() {
       expect(referMedia.constraints.video).toBe(false);
     });
   });
+
+  describe('.prepareIceServers', function() {
+    it('returns the expected structure for a single url', function() {
+      var stunServers = ['stun:stun.l.google.com:19302'];
+      var turnServers = [{ urls: ['turn:numb.viagenie.ca'], username: 'bob', password: 'dog' }];
+
+      var servers = MediaHandler.prepareIceServers(stunServers, turnServers);
+
+      var expectedServers = [
+        { urls: 'stun:stun.l.google.com:19302' },
+        { urls: ['turn:numb.viagenie.ca'], username: 'bob', credential: 'dog' }
+      ];
+
+      expect(servers).toEqual(expectedServers);
+    });
+
+    it('returns the expected structure for multiple urls', function() {
+      var stunServers = ['stun:stun.l.google.com:19302', 'stun:stun.l.google.com:555'];
+      var turnServers = [
+        { urls: ['turn:numb.viagenie.ca', 'turn:numb.viagenie.com'], username: 'bob', password: 'dog' },
+        { urls: ['turn:lump.viagenie.ca'], username: 'rob', password: 'cat' }
+      ];
+
+      var servers = MediaHandler.prepareIceServers(stunServers, turnServers);
+
+      var expectedServers = [
+        { urls: 'stun:stun.l.google.com:19302' },
+        { urls: 'stun:stun.l.google.com:555'   },
+        { urls: ['turn:numb.viagenie.ca', 'turn:numb.viagenie.com'], username: 'bob', credential: 'dog' },
+        { urls: ['turn:lump.viagenie.ca'], username: 'rob', credential: 'cat' }
+      ];
+
+      expect(servers).toEqual(expectedServers);
+    });
+  });
 });


### PR DESCRIPTION
In more recent versions of FF (>= 38) we're getting a deprecation
warning:

> RTCIceServer.url is deprecated! Use urls instead

This PR changes the iceServer preparation in 2 ways:

1. the property of a iceServer member is now `urls` not `url`.

There was already a comment hinting to this change:
> Change 'url' to 'urls' whenever this issue is solved:
  https://code.google.com/p/webrtc/issues/detail?id=2096
(The mentioned issue has been resolved.)

2. the turn server urls are no longer flattened and instead
passed on as an array.
(http://w3c.github.io/webrtc-pc/#idl-def-RTCIceServer)

Since there are 2 places (UA and MediaHandler) where the stun
and turn server options/configurations are modified
I wasn't 100% sure if this is the right place.

I've also added some specs. If you have any questions or suggestions,
I'm more than happy to address them.

Cheers