### PR TITLE
Move releases to master branch, use `npm version`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.min.js binary
+dist/* binary

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,25 +1,7 @@
 # How To version release SIP.js
 
-(These are developer notes.)
-
-(These may not be entirely accurate.)
-
-(Eric Green demands credit for these.)
-
-(So remember that if it's broken, you know who to contact.)
-
-(If you don't know, it's Eric Green.)
-
-* On your own github, checkout last tagged release on a new branch (note: this can be done on the repo's release branch, instead of making your own)
-* remove all dist files
-* cherry pick commits you want using -x flag (for "hot patch" releases)
-* once ready, test.
-* update version number on master
-* cherry pick version number commit to new branch (or just merge master, if you want everything)
-* build and test.
-* test again
-* add new dist files (git add -f if it complains)
-* commit
+* `git checkout master && git pull`
+* `npm version patch # patch/minor/major`
 * test npm:
 
     ```shell
@@ -68,11 +50,7 @@
     set +e
     ```
 
-* push to local github
-* merge (this step and the above one can be skipped if you just do it on the the repo's release branch itself)
-* git tag (your version number)
-* git push --tags
-* get a clean release (as in, fresh clone)
-* npm publish
+* `npm publish`
+* `git push --follow-tags`
 * do release notes on github and release!
 * update website

--- a/package.json
+++ b/package.json
@@ -46,7 +46,11 @@
   "scripts": {
     "repl": "beefy test/repl.js --open",
     "build": "grunt build",
+    "version:build": "git clean -fxd && npm install && grunt && git add -f dist",
+    "version:bower": "node ./scripts/version_bower.js && git add bower.json",
+    "version": "npm run version:build && npm run version:bower",
     "prepublish": "cd src/Grammar && mkdir -p dist && pegjs --extra-options-file peg.json src/Grammar.pegjs dist/Grammar.js",
+    "postpublish": "git rm -rf dist && git commit -am 'Remove dist/ files'",
     "postinstall": "[ -f src/Grammar/dist/Grammar.js ] || npm run-script prepublish",
     "test": "grunt travis --verbose"
   },

--- a/scripts/version_bower.js
+++ b/scripts/version_bower.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+"use strict";
+
+// This is run during `npm version`, to update the version in bower.json
+// See https://github.com/onsip/SIP.js/pull/310#issuecomment-209517244
+var fs = require("fs");
+var npm_version = JSON.parse(fs.readFileSync("package.json")).version;
+var bower_json = JSON.parse(fs.readFileSync("bower.json"));
+bower_json.version = npm_version;
+fs.writeFileSync("bower.json", JSON.stringify(bower_json, null, 2));


### PR DESCRIPTION
[Issue 291] reminded me how much of a pain it is to prepare and publish
a new release, so I thought I'd try out something different, inspired by
[webtorrent]. Instead of having a separate release branch, let's just
keep releases on master. This avoids all the extra git stuff required to
do it the old way, while still supporting bower users by checking in
`dist/` files upon release.

With these changes, preparing a release is as simple as

    npm version patch # patch/minor/major/etc

Using the [scripts] in package.json, this will:

* Remove old `dist/` files
* Reinstall `node_modules` from scratch
* Do a clean build and test
* Add new `dist/` files
* Bump version numbers in `package.json` and `bower.json`
* Commit and tag the release

This result will be a single tagged commit with all the changes in
`dist/`, `package.json`, and `bower.json`.

After that, all that's needed to publish the release is:

    npm publish # for npm
    git push --follow-tags # for bower

`npm publish` creates a new commit that removes the `dist/` directory,
so that it can remain ignored until the next release.

[Issue 291]: https://github.com/onsip/SIP.js/pull/291#issuecomment-208897713
[webtorrent]: https://github.com/feross/webtorrent
[scripts]: https://docs.npmjs.com/cli/version