### PR TITLE
add postinstall script for npm install from git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "repl": "beefy test/repl.js --open",
     "build": "grunt build",
     "prepublish": "cd src/Grammar && mkdir -p dist && pegjs --extra-options-file peg.json src/Grammar.pegjs dist/Grammar.js",
+    "postinstall": "[ -f src/Grammar/dist/Grammar.js ] || npm run-script prepublish",
     "test": "grunt travis --verbose"
   },
   "dependencies": {


### PR DESCRIPTION
add checks for Grammar/dist.
because sometimes we need to npm install from remote git, but npm will not execute `prepublish` currently.

add postinstall that checks existence of Grammar/dist, if not, invoke script in prepublish