### PR TITLE
add ice into candidate if not in sdp.

### DIFF
--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -494,8 +494,19 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
         }
         return deferred.promise;
       })
-      .then(function readySuccess () {
-        var sdp = pc.localDescription.sdp;
+      .then(function shouldAppendIceToSdp() {
+        // TODO: should make this optional if we want to support ICE Trickling
+        if (pc.localDescription.sdp.indexOf('candidate') < 0) {
+          return SIP.Utils.promisify(pc, methodName, true)(constraints)
+            .then(function(sdp){
+              return sdp.sdp;
+            });
+        } else {
+          return '';
+        }
+      })
+      .then(function readySuccess (sdp) {
+        sdp = sdp || pc.localDescription.sdp;
 
         sdp = SIP.Hacks.Chrome.needsExplicitlyInactiveSDP(sdp);
         sdp = SIP.Hacks.AllBrowsers.unmaskDtls(sdp);


### PR DESCRIPTION
some WebRTC implementation may not include ice candidate after createOffer/createAnswer.

Since sip.js doesn't support ice trickling and using defer to wait all candidates to be found, we need to make sure our sdp has ice candidates.

It would be better to make it optional and default enabled for future support of ice trickling.
