### PR TITLE
Session emits "confirmed" with the ACK

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -1498,6 +1498,8 @@ InviteServerContext.prototype = {
         this.renderbody = request.body;
         this.rendertype = contentType;
       }
+
+      this.emit('confirmed', request);
     }
 
     switch(request.method) {

--- a/src/Transactions.js
+++ b/src/Transactions.js
@@ -649,7 +649,7 @@ var checkTransaction = function(ua, request) {
         if(tr.state === C.STATUS_ACCEPTED) {
           return false;
         } else if(tr.state === C.STATUS_COMPLETED) {
-          tr.state = C.STATUS_CONFIRMED;
+          tr.stateChanged(C.STATUS_CONFIRMED);
           tr.I = SIP.Timers.setTimeout(tr.timer_I.bind(tr), SIP.Timers.TIMER_I);
           return true;
         }

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -1446,6 +1446,7 @@ describe('InviteServerContext', function() {
         InviteServerContext.hasAnswer = true;
 
         spyOn(SIP.Timers, 'clearTimeout').and.callThrough();
+        spyOn(InviteServerContext, 'emit');
         InviteServerContext.dialog = new SIP.Dialog(InviteServerContext, req, 'UAS');
 
         InviteServerContext.receiveRequest(req);
@@ -1454,6 +1455,8 @@ describe('InviteServerContext', function() {
         expect(SIP.Timers.clearTimeout).toHaveBeenCalledWith(InviteServerContext.timers.invite2xxTimer);
 
         expect(InviteServerContext.status).toBe(12);
+        expect(InviteServerContext.emit.calls.mostRecent().args[0]).toBe('confirmed');
+        expect(InviteServerContext.emit.calls.mostRecent().args[1]).toBe(req);
       });
     });
 


### PR DESCRIPTION
Hi SIP.js Team,

Here is the followup to #296. I included the first commit, "checkTransaction should use stateChanged", because @james-criscuolo indicated it would be worth taking; however, the real change though is in the second commit, which updates Session to emit a "confirmed" event with the ACK it receives.

Thanks,
Mark