### PR TITLE
add allowLegacyNotifications parameter to deal with non-subscription NOTIFIES

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -683,6 +683,14 @@ UA.prototype.receiveRequest = function(request) {
          * and without To tag.
          */
         break;
+      case SIP.C.NOTIFY:
+        if (this.configuration.allowLegacyNotifications && this.listeners('notify').length > 0) {
+          request.reply(200, null);
+          self.emit('notify', {request: request});
+        } else {
+          request.reply(481, 'Subscription does not exist');
+        }
+        break;
       default:
         request.reply(405);
         break;
@@ -914,7 +922,9 @@ UA.prototype.loadConfig = function(configuration) {
 
       authenticationFactory: checkAuthenticationFactory(function authenticationFactory (ua) {
         return new SIP.DigestAuthentication(ua);
-      })
+      }),
+
+      allowLegacyNotifications: false
     };
 
   // Pre-Configuration
@@ -1151,6 +1161,7 @@ UA.configuration_skeleton = (function() {
       "media",
       "mediaConstraints",
       "authenticationFactory",
+      "allowLegacyNotifications",
 
       // Post-configuration generated parameters
       "via_core_value",
@@ -1590,7 +1601,13 @@ UA.configuration_check = {
       }
     },
 
-    authenticationFactory: checkAuthenticationFactory
+    authenticationFactory: checkAuthenticationFactory,
+
+    allowLegacyNotifications: function(allowLegacyNotifications) {
+      if (typeof allowLegacyNotifications === 'boolean') {
+        return allowLegacyNotifications;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
This PR is for dealing with older devices/systems that are standards-compliant according to RFC 3265 instead of RFC 6665. The relevant pieces:

- [RFC 3265 Section 3.2](https://tools.ietf.org/html/rfc3265#section-3.2)
> NOTIFY messages are sent to inform subscribers of changes in state to
   which the subscriber has a subscription.  Subscriptions are typically
   put in place using the SUBSCRIBE method; however, it is possible that
   other means have been used.

  > If any non-SUBSCRIBE mechanisms are defined to create subscriptions,
   it is the responsibility of the parties defining those mechanisms to
   ensure that correlation of a NOTIFY message to the corresponding
   subscription is possible.  Designers of such mechanisms are also
   warned to make a distinction between sending a NOTIFY message to a
   subscriber who is aware of the subscription, and sending a NOTIFY
   message to an unsuspecting node.  The latter behavior is invalid, and
   MUST receive a "481 Subscription does not exist" response (unless
   some other 400- or 500-class error code is more applicable), as
   described in section 3.2.4.  In other words, knowledge of a
   subscription must exist in both the subscriber and the notifier to be
   valid, even if installed via a non-SUBSCRIBE mechanism.

- [RFC 6665 Section 3.2](https://tools.ietf.org/html/rfc6665#section-3.2)
> NOTIFY requests are sent to inform subscribers of changes in state to
   which the subscriber has a subscription.  Subscriptions are created
   using the SUBSCRIBE method.  In legacy implementations, it is
   possible that other means of subscription creation have been used.
   However, this specification does not allow the creation of
   subscriptions except through SUBSCRIBE requests and (for backwards-
   compatibility) REFER requests [RFC3515].

This PR adds an optional UA configuration parameter, `allowLegacyNotifications`, that allows a listener to be set up on the UA to listen for NOTIFYs that do not belong to any subscribe, and if no such listener is set up (or the parameter is false), we reject with `481 Subscription does not exist` as the 3265 describes.