### PR TITLE
Reallow passing functions as media render hint

### DIFF
--- a/src/WebRTC/MediaStreamManager.js
+++ b/src/WebRTC/MediaStreamManager.js
@@ -75,10 +75,10 @@ MediaStreamManager.render = function render (streams, elements) {
   }
 
   function attachAndPlay (elements, stream, index) {
-    if (typeof elements === 'function') {
-      elements = elements();
-    }
     var element = elements[index % elements.length];
+    if (typeof element === 'function') {
+      element = element();
+    }
     (environment.attachMediaStream || attachMediaStream)(element, stream);
     ensureMediaPlaying(element);
   }


### PR DESCRIPTION
Closes https://github.com/onsip/SIP.js/issues/329

Kudos to @matthieusieben for noticing this. It was broken by
commit d70d06730a1057757e0c937fd5f2af048e7131bb.

Here's a test you can run within `npm run repl`:

    var session = new SIP.UA().invite('welcome@onsip.com', {
      media: {
        render: {
          remote: [
            () => document.createElement('audio'),
          ],
        }
      }
    });