### PR TITLE
Method is `sendRequest`, not `request`

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -1130,7 +1130,7 @@ InviteServerContext.prototype = {
 
       this.receiveRequest = function(request) {
         if (request.method === SIP.C.ACK) {
-          this.request(SIP.C.BYE, {
+          this.sendRequest(SIP.C.BYE, {
             extraHeaders: extraHeaders,
             body: body
           });


### PR DESCRIPTION
Hi SIP.js Team,

I found a small bug in the InviteServerContext's `terminate` method. We were calling `request` instead of `sendRequest`.