### PR TITLE
Add hackCleanJitsiSdpImageattr UA option

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -904,6 +904,7 @@ UA.prototype.loadConfig = function(configuration) {
       hackIpInContact: false,
       hackWssInTransport: false,
       hackAllowUnregisteredOptionTags: false,
+      hackCleanJitsiSdpImageattr: false,
 
       contactTransport: 'ws',
       forceRport: false,
@@ -1138,6 +1139,7 @@ UA.configuration_skeleton = (function() {
       "hackIpInContact", //false
       "hackWssInTransport", //false
       "hackAllowUnregisteredOptionTags", //false
+      "hackCleanJitsiSdpImageattr", //false
       "contactTransport", // 'ws'
       "forceRport", // false
       "iceCheckingTimeout",
@@ -1336,6 +1338,12 @@ UA.configuration_check = {
     hackAllowUnregisteredOptionTags: function(hackAllowUnregisteredOptionTags) {
       if (typeof hackAllowUnregisteredOptionTags === 'boolean') {
         return hackAllowUnregisteredOptionTags;
+      }
+    },
+
+    hackCleanJitsiSdpImageattr: function(hackCleanJitsiSdpImageattr) {
+      if (typeof hackCleanJitsiSdpImageattr === 'boolean') {
+        return hackCleanJitsiSdpImageattr;
       }
     },
 


### PR DESCRIPTION
Jitsi likes to send INVITEs with invalid `a=imageattr` lines like:

    a=imageattr:96 send * recv [x=[0-1920],y=[0-1080]]

When applying the SDP to a PeerConnection, Firefox doesn't tolerate
these malformed lines (here's the RFC [grammar]), and throws an error like:

    DOMException [InvalidSessionDescriptionError:
    "Failed to parse SDP: SDP Parse Error on line 21: Value too small at column 20"
    code: 0
    nsresult: 0x0]

Normally, this sort of SDP mangling would be done in a 'setDescription'
listener on the Session's MediaHandler, but SIP.js attempts to apply the
INVITE's SDP to the PeerConnection before the application is aware of the
session, as described in https://github.com/onsip/SIP.js/issues/75#issuecomment-55045403,
so we need another way to handle this situation.

This commit adds a new opt-in UA configuration option, `hackCleanJitsiSdpImageattr`,
that causes the WebRTC MediaHandler to replace invalid SDP like the
above with the following, which is valid and can be parsed by Firefox:

    a=imageattr:96 send * recv [x=[1:1920],y=[1:1080]]

[grammar]: https://tools.ietf.org/html/rfc6236#section-3.1.1