### PR TITLE
Don't test Node v5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: node_js
 node_js:
   - "0.10"
   - "4.2"
-  - "5"
   - "stable"
 
 cache:


### PR DESCRIPTION
Node.js v5 support ends today, according to the release [announcement]:

> This new version of Node.js, however, will only be supported for 8
> months, with a new major version, v6, being released in April 2016.

Here's the complete support [schedule], for more information on when
various versions become unsupported.

[announcement]: https://nodejs.org/en/blog/release/v5.0.0/
[schedule]: https://github.com/nodejs/LTS#lts-schedule

EDIT: Hmm, looks like Travis hasn't picked up on this PR (yet?). Here's the build from my fork: https://travis-ci.org/josephfrazier/SIP.js/builds/141370565