### PR TITLE
Handle INFO requests in early dialogs

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -674,7 +674,8 @@ Session.prototype = {
             this.status === C.STATUS_WAITING_FOR_ACK ||
             this.status === C.STATUS_ANSWERED_WAITING_FOR_PRACK ||
             this.status === C.STATUS_EARLY_MEDIA ||
-            this.status === C.STATUS_CONFIRMED) {
+            this.status === C.STATUS_CONFIRMED ||
+            this.dialog) {
           if (this.onInfo) {
             return this.onInfo(request);
           }

--- a/src/Session.js
+++ b/src/Session.js
@@ -669,7 +669,12 @@ Session.prototype = {
         }
         break;
       case SIP.C.INFO:
-        if(this.status === C.STATUS_CONFIRMED || this.status === C.STATUS_WAITING_FOR_ACK) {
+        if (this.status === C.STATUS_1XX_RECEIVED ||
+            this.status === C.STATUS_WAITING_FOR_PRACK ||
+            this.status === C.STATUS_WAITING_FOR_ACK ||
+            this.status === C.STATUS_ANSWERED_WAITING_FOR_PRACK ||
+            this.status === C.STATUS_EARLY_MEDIA ||
+            this.status === C.STATUS_CONFIRMED) {
           if (this.onInfo) {
             return this.onInfo(request);
           }


### PR DESCRIPTION
Session should handle INFO requests whenever a dialog is established, even if the dialog is early. Before this change, INFO requests were only handled when the Session's status was `STATUS_WAITING_FOR_ACK` or `STATUS_CONFIRMED`, i.e. after sending a 200 OK or receiving an ACK. Now, Session will handle INFO requests when its status is any of the following
- `STATUS_1XX_RECEIVED`: the UAC received a 101-199 response
- `STATUS_WAITING_FOR_PRACK`: the UAS sent a 18x response (and is awaiting a PRACK)
- `STATUS_WAITING_FOR_ACK`: the UAS sent a 200 OK
- `STATUS_ANSWERED_WAITING_FOR_PRACK`: the UAS sent a 18x response (and `accept` was called before receiving a PRACK)
- `STATUS_EARLY_MEDIA`: the UAC received a 18x response or the UAS received a PRACK
- `STATUS_CONFIRMED`: the UAS received an ACK

Per [RFC 6086, Section 4.2.1, "INFO Request Sender"](https://tools.ietf.org/html/rfc6086#section-4.2.1):

> The construction of the INFO request is the same as any other
> non-target refresh request within an existing invite dialog usage as
> described in Section 12.2 of RFC 3261.

And [RFC 3261, Section 12.1, "Creation of a Dialog"](https://tools.ietf.org/html/rfc3261#section-12.1):

> Dialogs are created through the generation of non-failure responses
> to requests with specific methods.  Within this specification, only
> 2xx and 101-199 responses with a To tag, where the request was
> INVITE, will establish a dialog.  A dialog established by a non-final
> response to a request is in the "early" state and it is called an
> early dialog.
