### PR TITLE
Added a hack to strip TCP candidates from the sdp

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -905,6 +905,7 @@ UA.prototype.loadConfig = function(configuration) {
       hackWssInTransport: false,
       hackAllowUnregisteredOptionTags: false,
       hackCleanJitsiSdpImageattr: false,
+      hackStripTcp: false,
 
       contactTransport: 'ws',
       forceRport: false,
@@ -1140,6 +1141,7 @@ UA.configuration_skeleton = (function() {
       "hackWssInTransport", //false
       "hackAllowUnregisteredOptionTags", //false
       "hackCleanJitsiSdpImageattr", //false
+      "hackStripTcp", //false
       "contactTransport", // 'ws'
       "forceRport", // false
       "iceCheckingTimeout",
@@ -1344,6 +1346,12 @@ UA.configuration_check = {
     hackCleanJitsiSdpImageattr: function(hackCleanJitsiSdpImageattr) {
       if (typeof hackCleanJitsiSdpImageattr === 'boolean') {
         return hackCleanJitsiSdpImageattr;
+      }
+    },
+
+    hackStripTcp: function(hackStripTcp) {
+      if (typeof hackStripTcp === 'boolean') {
+        return hackStripTcp;
       }
     },
 

--- a/src/WebRTC/MediaHandler.js
+++ b/src/WebRTC/MediaHandler.js
@@ -518,6 +518,10 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
 
         self.emit('getDescription', sdpWrapper);
 
+        if (self.session.ua.configuration.hackStripTcp) {
+          sdpWrapper.sdp = sdpWrapper.sdp.replace(/^a=candidate:\d+ \d+ tcp .*?\r\n/img, "");
+        }
+
         self.ready = true;
         return sdpWrapper.sdp;
       })


### PR DESCRIPTION
This hack enables the removing of candidates of type TCP from the SDP provided in the proxy server ACK. To turn on the hack, set session.ua.configuration.hackStripTcp to "true."