### PR TITLE
Update and simplify attachMediaStream

### DIFF
--- a/src/WebRTC/MediaStreamManager.js
+++ b/src/WebRTC/MediaStreamManager.js
@@ -50,22 +50,13 @@ MediaStreamManager.render = function render (streams, elements) {
   }
 
   function attachMediaStream(element, stream) {
-    if (typeof element.src !== 'undefined') {
-      environment.revokeObjectURL(element.src);
-      element.src = environment.createObjectURL(stream);
-    } else if (typeof (element.srcObject || element.mozSrcObject) !== 'undefined') {
-      element.srcObject = element.mozSrcObject = stream;
-    } else {
-      return false;
-    }
-
-    return true;
+    element.srcObject = stream;
   }
 
   function ensureMediaPlaying (mediaElement) {
     var interval = 100;
     mediaElement.ensurePlayingIntervalId = SIP.Timers.setInterval(function () {
-      if (mediaElement.paused) {
+      if (mediaElement.paused && mediaElement.srcObject) {
         mediaElement.play();
       }
       else {


### PR DESCRIPTION
Hi!

Since adapter.js has deprecated and removed `attachMediaStream`
with the createObjectURL work-around [1] (quite a while back) and according to the spec
one should be using `srcObject` assignment [2]
I was wondering if this should be updated here as well.

Essentially reducing `attachMediaStream` to:

    element.srcObject = stream;

As far as extending the conditional in `attachAndPlay`:

    if (mediaElement.paused && mediaElement.srcObject)

One caveat with (`ensureMediaPlaying`) is if the element is modified
within the interval and no longer has a `srcObject` property on the
next invocation, the interval will be called indefinitely.

    // Uncaught (in promise) DOMException: The element has no supported sources.

This could cause problems for people who use something like [3] [4]

    videoElement.srcObject = null;

as a way to "de-attach" a mediaStream.

[1] https://github.com/webrtc/adapter/pull/334
[2] https://w3c.github.io/mediacapture-main/getusermedia.html#direct-assignment-to-media-elements
[3] https://github.com/search?utf8=%E2%9C%93&q=%22.srcObject+%3D+null%3B%22+in%3Afile+filename%3A*.js&type=Code&ref=searchresults
[4] https://github.com/webrtc/adapter/issues/59