### PR TITLE
Fix for missing ACK on PRACK on incoming call (incoming calls were terminating after 30 seconds if rel100 were used)

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -1588,7 +1588,7 @@ InviteServerContext.prototype = {
           //REVISIT
           this.mute();
         }
-      } else if(this.status === C.STATUS_EARLY_MEDIA) {
+      } else if(this.status === C.STATUS_EARLY_MEDIA || this.status === C.STATUS_WAITING_FOR_ANSWER) {
         request.reply(200);
       }
       break;


### PR DESCRIPTION
If sipjs were used with rel100, then on incoming calls sipjs were not answering with ACK on PRACK (which is required by RFC). This caused asterisk to terminate call after ~30 seconds due to missing ACK.