### PR TITLE
Removed references to closed WebSocket

### DIFF
--- a/src/Transport.js
+++ b/src/Transport.js
@@ -124,6 +124,7 @@ Transport.prototype = {
       this.closed = true;
       this.logger.log('closing WebSocket ' + this.server.ws_uri);
       this.ws.close();
+      this.ws = null;
     }
 
     if (this.reconnectTimer !== null) {
@@ -150,6 +151,7 @@ Transport.prototype = {
 
     if(this.ws) {
       this.ws.close();
+      this.ws = null;
     }
 
     this.logger.log('connecting to WebSocket ' + this.server.ws_uri);
@@ -170,6 +172,11 @@ Transport.prototype = {
 
     this.ws.onclose = function(e) {
       transport.onClose(e);
+      // Always cleanup. Eases GC, prevents potential memory leaks.
+      this.onopen = null;
+      this.onclose = null;
+      this.onmessage = null;
+      this.onerror = null;
     };
 
     this.ws.onmessage = function(e) {


### PR DESCRIPTION
Whenever the WebSocket is closed, remove any reference to it.

Also, remove the listeners setup on the WebSocket in case some other part of the code does nasty stuff an keeps a reference to it. In that case, only the WebSocket will remain in memory and not the whole UA instance.