### PR TITLE
Give access to more events when things happen

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -236,7 +236,7 @@ UA.prototype.invite = function(target, options) {
   var context = new SIP.InviteClientContext(this, target, options);
 
   this.afterConnected(context.invite.bind(context));
-  this.emit('invite-sent', context);
+  this.emit('inviteSent', context);
   return context;
 };
 

--- a/src/UA.js
+++ b/src/UA.js
@@ -236,6 +236,7 @@ UA.prototype.invite = function(target, options) {
   var context = new SIP.InviteClientContext(this, target, options);
 
   this.afterConnected(context.invite.bind(context));
+  this.emit('invite-sent', context);
   return context;
 };
 


### PR DESCRIPTION
This PR adds 5 new events

`peerConnection-setRemoteDescriptionFailed`
`peerConnection-createAnswerFailed`
`peerConnection-createOfferFailed`
`peerConnection-setLocalDescriptionFailed`
`inviteSent`

This is for better integration into WebRTC analysis tooling