### PR TITLE
Check whether constraints have changed before calling getUserMedia

### DIFF
--- a/src/WebRTC/SessionDescriptionHandler.js
+++ b/src/WebRTC/SessionDescriptionHandler.js
@@ -113,13 +113,14 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
       this.initPeerConnection(options.peerConnectionOptions);
     }
 
-    if (this.constraints && options.constraints && this.constraints === options.constraints) {
-      shouldAcquireMedia = false;
-    }
-
     // Merge passed constraints with saved constraints and save
-    this.constraints = Object.assign(this.constraints, options.constraints);
-    this.constraints = this.checkAndDefaultConstraints(this.constraints);
+    var newConstraints = Object.assign({}, this.constraints, options.constraints);
+    newConstraints = this.checkAndDefaultConstraints(newConstraints);
+    if (JSON.stringify(newConstraints) !== JSON.stringify(this.constraints)) {
+        this.constraints = newConstraints;
+    } else {
+        shouldAcquireMedia = false;
+    }
 
     modifiers = modifiers || [];
     if (!Array.isArray(modifiers)) {


### PR DESCRIPTION
The "if" condition could never be true, as we don't ever receive an
"options.constraints" object which *is* (reference equality) this.constraints.

Instead, prepare the target constraints by merging the current and new
constraints, and do a deep comparison with what we currently have.