### PR TITLE
Improve detection of ICE gathering complete

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
       'test/polyfills/*.js',
       'test/helpers/*.js',
       'dist/sip.js',
-      'test/spec/*.js'
+      'test/spec/**/*.js'
     ],
 
     // list of files to exclude
@@ -21,7 +21,9 @@ module.exports = function(config) {
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {},
+    preprocessors: {
+      'test/spec/WebRTC/SessionDescriptionHandler.spec.js': 'webpack'
+    },
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
@@ -62,10 +64,11 @@ module.exports = function(config) {
     concurrency: Infinity,
 
     plugins : [
-	    'karma-jasmine',
+      'karma-jasmine',
       'karma-jasmine-html-reporter',
       'karma-mocha-reporter',
-	    'karma-phantomjs-launcher'
-	  ]
+      'karma-phantomjs-launcher',
+      'karma-webpack'
+    ]
   })
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-mocha-reporter": "^2.2.5",
     "karma-phantomjs-launcher": "^1.0.4",
+    "karma-webpack": "^2.0.6",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.4",
     "uglifyjs-webpack-plugin": "^1.0.1",

--- a/test/spec/WebRTC/SessionDescriptionHandler.spec.js
+++ b/test/spec/WebRTC/SessionDescriptionHandler.spec.js
@@ -1,0 +1,187 @@
+var SessionDescriptionHandler = require('../../../src/WebRTC/SessionDescriptionHandler')(SIP);
+
+function setIceGatheringState(pc, state) {
+  pc.iceGatheringState = state;
+  pc.onicegatheringstatechange.call(pc);
+}
+
+describe('WebRTC/SessionDescriptionHandler', function() {
+  var realMediaDevices,
+    realRTCPeerConnection,
+    handler;
+
+  beforeEach(function() {
+    var mockSession = {
+      emit: function() {},
+      ua: {
+        getLogger: function() {
+          return console;
+        }
+      }
+    };
+
+    // stub out WebRTC APIs
+    realMediaDevices = window.navigator.mediaDevices;
+    realRTCPeerConnection = window.RTCPeerConnection;
+    window.RTCPeerConnection = function() {
+        this.iceGatheringState = 'new';
+    };
+    window.RTCPeerConnection.prototype.close = function() {};
+    window.RTCPeerConnection.prototype.getReceivers = function() {
+      return [];
+    };
+    window.RTCPeerConnection.prototype.getSenders = function() {
+      return [];
+    };
+
+    window.navigator.mediaDevices = {
+      getUserMedia: function() {}
+    };
+
+    handler = new SessionDescriptionHandler(mockSession, {
+      peerConnectionOptions: {
+        iceCheckingTimeout: 500
+      }
+    });
+  });
+
+  afterEach(function() {
+    handler.close();
+
+    window.navigator.mediaDevices = realMediaDevices;
+    window.RTCPeerConnection = realRTCPeerConnection;
+  });
+
+  it('creates instance', function() {
+    expect(handler).toBeTruthy();
+    expect(handler.iceGatheringDeferred).toBe(null);
+    expect(handler.iceGatheringTimeout).toBe(false);
+    expect(handler.iceGatheringTimer).toBe(null);
+    expect(handler.peerConnection).toBeTruthy();
+  });
+
+  it('waits for ice gathering to complete', function(done) {
+    handler.waitForIceGatheringComplete().then(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('complete');
+
+      done();
+    });
+
+    expect(handler.iceGatheringDeferred).toBeTruthy();
+    setIceGatheringState(handler.peerConnection, 'gathering');
+    setIceGatheringState(handler.peerConnection, 'complete');
+  });
+
+  it('waits for ice gathering to complete, twice', function(done) {
+    handler.waitForIceGatheringComplete().then(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('complete');
+
+      return handler.waitForIceGatheringComplete();
+    }).then(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('complete');
+
+      done();
+    });
+
+    expect(handler.iceGatheringDeferred).toBeTruthy();
+    setIceGatheringState(handler.peerConnection, 'gathering');
+    setIceGatheringState(handler.peerConnection, 'complete');
+  });
+
+  it('waits for ice gathering to timeout, then complete', function(done) {
+    handler.waitForIceGatheringComplete().then(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(true);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('gathering');
+
+      var promise = handler.waitForIceGatheringComplete();
+      expect(handler.iceGatheringDeferred).toBe(null); // no new promise!
+      expect(handler.iceGatheringTimeout).toBe(true);
+      expect(handler.iceGatheringTimer).toBe(null);
+
+      setIceGatheringState(handler.peerConnection, 'complete');
+
+      return promise;
+    }).then(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(true);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('complete');
+
+      done();
+    });
+
+    expect(handler.iceGatheringDeferred).toBeTruthy();
+    setIceGatheringState(handler.peerConnection, 'gathering');
+  });
+
+  it('waits for ice gathering to complete, then restart, then complete', function(done) {
+    handler.waitForIceGatheringComplete().then(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('complete');
+
+      var promise = handler.waitForIceGatheringComplete();
+      expect(handler.iceGatheringDeferred).toBe(null); // no new promise!
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+
+      setIceGatheringState(handler.peerConnection, 'gathering');
+      setIceGatheringState(handler.peerConnection, 'complete');
+
+      return promise;
+    }).then(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('complete');
+
+      done();
+    });
+
+    expect(handler.iceGatheringDeferred).toBeTruthy();
+    setIceGatheringState(handler.peerConnection, 'gathering');
+    setIceGatheringState(handler.peerConnection, 'complete');
+  });
+
+  it('waits for ice gathering to complete, resets peer connection, waits again', function(done) {
+    handler.waitForIceGatheringComplete().catch(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('new');
+
+      var promise = handler.waitForIceGatheringComplete();
+      expect(handler.iceGatheringDeferred).toBeTruthy(); // new promise!
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+
+      setIceGatheringState(handler.peerConnection, 'gathering');
+      setIceGatheringState(handler.peerConnection, 'complete');
+
+      return promise;
+    }).then(function() {
+      expect(handler.iceGatheringDeferred).toBe(null);
+      expect(handler.iceGatheringTimeout).toBe(false);
+      expect(handler.iceGatheringTimer).toBe(null);
+      expect(handler.peerConnection.iceGatheringState).toBe('complete');
+
+      done();
+    });
+
+    expect(handler.iceGatheringDeferred).toBeTruthy();
+    setIceGatheringState(handler.peerConnection, 'gathering');
+    handler.initPeerConnection();
+  });
+})


### PR DESCRIPTION
The previous detection mechanism had several issues:

- it also checked the iceConnectionState, which is unrelated

- it did not account for the fact iceGatheringState can go from
  'complete' back to 'gathering'

- it did not ensure the timer was stopped when destroying the
  session description handler

This also adds unit tests for the ICE gathering state changes.