### PR TITLE
Bind holdModifier to the SessionDescriptionHandler instance

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -416,7 +416,7 @@ Session.prototype = {
 
     options = options || {};
     options.modifiers = modifiers || [];
-    options.modifiers.push(this.sessionDescriptionHandler.holdModifier);
+    options.modifiers.push(this.sessionDescriptionHandler.holdModifier.bind(this.sessionDescriptionHandler));
 
     this.local_hold = true;
 


### PR DESCRIPTION
When putting a call on hold, sessionDescriptionHandler.holdModifier is
added to the modifiers. The modifier is an instance method, and as such
we need to bind it to the instance.

It so happens the default WebRTC holdModifier does not reference 'this',
so things work as expected. However for a custom session description
handler this may not hold true.