### PR TITLE
Fix G.722 stripping of non-audio call

### DIFF
--- a/src/WebRTC/Modifiers.js
+++ b/src/WebRTC/Modifiers.js
@@ -24,20 +24,23 @@ Modifiers = {
   },
 
   stripG722: function(description) {
-    var mline = description.sdp.match(/^m=audio.*$/gm)[0];
-    mline = mline.split(" ");
-    // Ignore the first 3 parameters of the mline. The codec information is after that
-    for (var i = 3; i < mline.length; i=i+1) {
-      if (mline[i] === "9") {
-        mline.splice(i, 1);
-        var numberOfCodecs = parseInt(mline[1], 10);
-        numberOfCodecs = numberOfCodecs - 1;
-        mline[1] = numberOfCodecs.toString();
+    var parts = description.sdp.match(/^m=audio.*$/gm);
+    if (parts) {
+      var mline = parts[0];
+      mline = mline.split(" ");
+      // Ignore the first 3 parameters of the mline. The codec information is after that
+      for (var i = 3; i < mline.length; i=i+1) {
+        if (mline[i] === "9") {
+          mline.splice(i, 1);
+          var numberOfCodecs = parseInt(mline[1], 10);
+          numberOfCodecs = numberOfCodecs - 1;
+          mline[1] = numberOfCodecs.toString();
+        }
       }
+      mline = mline.join(" ");
+      description.sdp = description.sdp.replace(/^m=audio.*$/gm, mline);
+      description.sdp = description.sdp.replace(/^a=rtpmap:.*G722\/8000\r\n?/gm, "").replace();
     }
-    mline = mline.join(" ");
-    description.sdp = description.sdp.replace(/^m=audio.*$/gm, mline);
-    description.sdp = description.sdp.replace(/^a=rtpmap:.*G722\/8000\r\n?/gm, "").replace();
     return SIP.Utils.Promise.resolve(description);
   }
 };


### PR DESCRIPTION
When making a video only call using the Simple API I was getting a error when stripping the G.722 codec ('cos it was on a Mac).
This PR checks that we've got a audio mline before referencing it.