### PR TITLE
Prefer getReceivers over getRemoteStreams

### DIFF
--- a/src/WebRTC/SessionDescriptionHandler.js
+++ b/src/WebRTC/SessionDescriptionHandler.js
@@ -273,11 +273,10 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
         throw e;
       })
       .then(function setRemoteDescriptionSuccess() {
-        if (self.peerConnection.getRemoteStreams) {
-          self.emit('setRemoteDescription', self.peerConnection.getRemoteStreams());
-        } else {
-          // This should be the default, and we should fall back to getRemoteStreams if this is not supported
+        if (self.peerConnection.getReceivers) {
           self.emit('setRemoteDescription', self.peerConnection.getReceivers());
+        } else {
+          self.emit('setRemoteDescription', self.peerConnection.getRemoteStreams());
         }
         self.emit('confirmed', self);
       });

--- a/src/WebRTC/Simple.js
+++ b/src/WebRTC/Simple.js
@@ -274,9 +274,7 @@ Simple.prototype.setupRemoteMedia = function() {
   var pc = this.session.sessionDescriptionHandler.peerConnection;
   var remoteStream;
 
-  if (pc.getRemoteStreams) {
-    remoteStream = pc.getRemoteStreams()[0];
-  } else {
+  if (pc.getReceivers) {
     remoteStream = new global.window.MediaStream();
     pc.getReceivers().forEach(function(receiver) {
       var track = receiver.track;
@@ -284,6 +282,8 @@ Simple.prototype.setupRemoteMedia = function() {
         remoteStream.addTrack(track);
       }
     });
+  } else {
+    remoteStream = pc.getRemoteStreams()[0];
   }
   if (this.video) {
     this.options.media.remote.video.srcObject = remoteStream;


### PR DESCRIPTION
In most places, we prefer to use the modern getReceivers/getSenders
instead of the legacy getRemoteStreams/getLocalStreams. However there
were two places where this logic was reversed.