### PR TITLE
Consistently use iceCheckingTimeout = 5000 as default value

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -932,10 +932,7 @@ UA.prototype.loadConfig = function(configuration) {
       // Session Description Handler Options
       sessionDescriptionHandlerFactoryOptions: {
         constraints: {},
-        peerConnectionOptions: {
-          iceCheckingTimeout: 5000,
-          rtcConfiguration: {}
-        }
+        peerConnectionOptions: {}
       },
 
       contactName: SIP.Utils.createRandomToken(8), // user name in user part

--- a/src/WebRTC/SessionDescriptionHandler.js
+++ b/src/WebRTC/SessionDescriptionHandler.js
@@ -324,6 +324,13 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
       });
   }},
 
+  addDefaultIceCheckingTimeout: {writable: true, value: function addDefaultIceCheckingTimeout (peerConnectionOptions) {
+    if (peerConnectionOptions.iceCheckingTimeout === undefined) {
+      peerConnectionOptions.iceCheckingTimeout = 5000;
+    }
+    return peerConnectionOptions;
+  }},
+
   addDefaultIceServers: {writable: true, value: function addDefaultIceServers (rtcConfiguration) {
     if (!rtcConfiguration.iceServers) {
       rtcConfiguration.iceServers = [{urls: 'stun:stun.l.google.com:19302'}];
@@ -344,6 +351,7 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
   initPeerConnection: {writable: true, value: function initPeerConnection(options) {
     var self = this;
     options = options || {};
+    options = this.addDefaultIceCheckingTimeout(options);
     options.rtcConfiguration = options.rtcConfiguration || {};
     options.rtcConfiguration = this.addDefaultIceServers(options.rtcConfiguration);
 

--- a/test/spec/SpecUA.js
+++ b/test/spec/SpecUA.js
@@ -1247,12 +1247,6 @@ describe('UA', function() {
       expect(UA.configuration.authorizationUser).toBe(UA.configuration.uri.user);
     });
 
-    xit('sets iceCheckingTimeout as low as 0.5 seconds', function() {
-      UA.loadConfig({iceCheckingTimeout: 0});
-
-      expect(UA.configuration.iceCheckingTimeout).toBe(500);
-    });
-
     it('sets the registrarServer to the uri (without user) if it is not passed in', function() {
       UA.loadConfig({uri: 'james@onsnip.onsip.com'});
 

--- a/test/spec/WebRTC/SessionDescriptionHandler.spec.js
+++ b/test/spec/WebRTC/SessionDescriptionHandler.spec.js
@@ -60,6 +60,27 @@ describe('WebRTC/SessionDescriptionHandler', function() {
     expect(handler.peerConnection).toBeTruthy();
   });
 
+  it('adds default ice gathering timeout', function() {
+    // no value
+    expect(handler.addDefaultIceCheckingTimeout({})).toEqual({
+      iceCheckingTimeout: 5000
+    });
+
+    // 0 value to disable the timeout
+    expect(handler.addDefaultIceCheckingTimeout({
+      iceCheckingTimeout: 0
+    })).toEqual({
+      iceCheckingTimeout: 0
+    });
+
+    // other value
+    expect(handler.addDefaultIceCheckingTimeout({
+      iceCheckingTimeout: 1234
+    })).toEqual({
+      iceCheckingTimeout: 1234
+    });
+  });
+
   it('waits for ice gathering to complete', function(done) {
     handler.waitForIceGatheringComplete().then(function() {
       expect(handler.iceGatheringDeferred).toBe(null);

--- a/test/spec/WebRTC/Simple.spec.js
+++ b/test/spec/WebRTC/Simple.spec.js
@@ -1,0 +1,40 @@
+describe('WebRTC/Simple', function() {
+  beforeEach(function() {
+    spyOn(SIP, 'UA').and.callFake(function(configuration) {
+      this.configuration = configuration;
+      this.getLogger = function() {
+        return console;
+      };
+      this.on = function() {};
+    });
+  });
+
+  it('creates instance', function() {
+    var simple = new SIP.WebRTC.Simple({
+      media: {
+        remote: {
+          audio: {}
+        }
+      },
+      ua: {
+        uri: 'bob@example.com',
+        wsServers: ['wss://sip-ws.example.com'],
+      }
+    });
+    expect(simple).toBeTruthy();
+    expect(simple.ua.configuration).toEqual({
+      authorizationUser: undefined,
+      displayName: undefined,
+      password: undefined,
+      register: true,
+      sessionDescriptionHandlerFactoryOptions: {
+        // FIXME: phantomjs is detected as safari!
+        modifiers: [SIP.WebRTC.Modifiers.stripG722]
+      },
+      traceSip: undefined,
+      uri: 'bob@example.com',
+      userAgentString: undefined,
+      wsServers: ['wss://sip-ws.example.com'],
+    });
+  });
+});


### PR DESCRIPTION
Currently, UA uses a sensible default iceCheckingTimeout: 5000.

However, as Simple overrides sessionDescriptionHandlerFactoryOptions, it loses
this default value and as a result does not use any iceCheckingTimeout.

This also adds a test to check the default options used by Simple.