### PR TITLE
Remove reference to rtcpMuxPolicy

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -1420,12 +1420,6 @@ UA.prototype.getConfigurationCheck = function () {
         }
       },
 
-      rtcpMuxPolicy: function(rtcpMuxPolicy) {
-        if (typeof rtcpMuxPolicy === 'string') {
-          return rtcpMuxPolicy;
-        }
-      },
-
       userAgentString: function(userAgentString) {
         if (typeof userAgentString === 'string') {
           return userAgentString;


### PR DESCRIPTION
This is no longer passed directly in the UA configuration but inside
sessionDescriptionHandlerOptions.peerConnectionOptions.rtcConfiguration