### PR TITLE
Use babel-loader to transpile code

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "javascript"
   ],
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
     "eslint": "^4.9.0",
-    "eslint-loader": "^1.9.0",
     "jasmine-core": "^2.8.0",
     "karma": "^1.7.1",
     "karma-cli": "^1.0.1",
@@ -46,6 +48,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "prebuild": "eslint src/*.js src/**/*.js",
     "build": "webpack --progress && cp dist/sip.js dist/sip-$npm_package_version.js && cp dist/sip.min.js  dist/sip-$npm_package_version.min.js",
     "browserTest": "sleep 2 && open http://0.0.0.0:9876/debug.html & karma start --reporters kjhtml --no-single-run",
     "commandLineTest": "karma start --reporters mocha --browsers PhantomJS --single-run",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,9 +53,9 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: "eslint-loader",
+        loader: "babel-loader",
         options: {
-          // eslint options (if necessary)
+          presets: ['env']
         }
       },
       {


### PR DESCRIPTION
Switch from eslint-loader to babel-loader to allow using modern constructs
such as arrow functions or ES6 classes while still retaining "compatibility"
with older browsers. It's worth mentioning browsers which support WebRTC
already ship with ES6 support, but at least we won't trigger parser errors
on the older browsers.

The cost in terms of runtime size is negligeable, the minified code grows
by less than 400 bytes as a result of the switch. Note: we don't pull in
any polyfills with this commit, so only ES6 constructs are supported, not
using new classes such as Map or Set.

We still perform linting as part of the build, by invoking eslint in the
prebuild step.