### PR TITLE
Immutable constraints in setDescription of Session

### DIFF
--- a/src/WebRTC/SessionDescriptionHandler.js
+++ b/src/WebRTC/SessionDescriptionHandler.js
@@ -242,7 +242,7 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
     }
 
     // Merge passed constraints with saved constraints and save
-    this.constraints = Object.assign(this.constraints, options.constraints);
+    this.constraints = Object.assign({}, this.constraints, options.constraints);
     this.constraints = this.checkAndDefaultConstraints(this.constraints);
 
     modifiers = modifiers || [];


### PR DESCRIPTION
Constraints were modifying an object directly. I added an empty object that is mutable, leaving the others immutable.

I had this issue with React-Native: 
![screen shot 2017-11-28 at 4 06 22 pm](https://user-images.githubusercontent.com/6422160/33344375-ccdd1d92-d456-11e7-9fee-8fe2d22adb43.png)
