### PR TITLE
Prefer ontrack over onaddstream, remove onremovestream

### DIFF
--- a/src/WebRTC/SessionDescriptionHandler.js
+++ b/src/WebRTC/SessionDescriptionHandler.js
@@ -370,21 +370,18 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
     this.logger.log('New peer connection created');
     this.session.emit('peerConnection-created', this.peerConnection);
 
-    this.peerConnection.ontrack = function(e) {
-      self.logger.log('track added');
-      self.emit('addTrack', e);
-    };
-
-    this.peerConnection.onaddstream = function(e) {
-      self.logger.warn('Using deprecated stream API');
-      self.logger.log('stream added');
-      self.emit('addStream', e);
-    };
-
-    // TODO: There is no remove track listener
-    this.peerConnection.onremovestream = function(e) {
-      self.logger.log('stream removed: '+ e.stream.id);
-    };
+    if ('ontrack' in this.peerConnection) {
+      this.peerConnection.ontrack = function(e) {
+        self.logger.log('track added');
+        self.emit('addTrack', e);
+      };
+    } else {
+      this.logger.warn('Using onaddstream which is deprecated');
+      this.peerConnection.onaddstream = function(e) {
+        self.logger.log('stream added');
+        self.emit('addStream', e);
+      };
+    }
 
     this.peerConnection.onicecandidate = function(e) {
       self.emit('iceCandidate', e);


### PR DESCRIPTION
Until now, we used *both* the spec-compliant ontrack and the deprecated
onaddstream APIs to detect track/stream addition. This resulted in a
warning even on spec-compliant browsers which implement ontrack.

We now detect support for ontrack and only use onaddstream as a fallback,
and emit a more explicit warning message, formatted like the two other
warnings about deprecated WebRTC APIs.

We also remove the deprecated onremovestream which did nothing except
print a logging message.