### PR TITLE
Make SIP.js (hopefully) buildable on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.min.js binary
+
+# eslint expects all JS files to have Unix line endings
+*.js text eol=lf

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-preset-env": "^1.6.1",
+    "cpr": "^3.0.1",
+    "cross-env": "^5.1.3",
     "eslint": "^4.9.0",
     "jasmine-core": "^2.8.0",
     "karma": "^1.7.1",
@@ -49,7 +51,7 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "eslint src/*.js src/**/*.js",
-    "build": "webpack --progress && cp dist/sip.js dist/sip-$npm_package_version.js && cp dist/sip.min.js  dist/sip-$npm_package_version.min.js",
+    "build": "webpack --progress && cross-env cpr dist/sip.js dist/sip-$npm_package_version.js -o && cross-env cpr dist/sip.min.js dist/sip-$npm_package_version.min.js -o",
     "browserTest": "sleep 2 && open http://0.0.0.0:9876/debug.html & karma start --reporters kjhtml --no-single-run",
     "commandLineTest": "karma start --reporters mocha --browsers PhantomJS --single-run",
     "buildAndTest": "npm run build && npm run commandLineTest"


### PR DESCRIPTION
If eslint requires LF, make sure JS files get checked out that way