### PR TITLE
Emit "terminated" on renegotiation error (+ test fix)

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -593,6 +593,7 @@ Session.prototype = {
           self.sendRequest(SIP.C.BYE, {
             extraHeaders: ['Reason: ' + SIP.Utils.getReasonHeaderValue(488, 'Not Acceptable Here')]
           });
+          self.terminated(null, SIP.C.causes.INCOMPATIBLE_SDP);
         }).then(function() {
           self.emit('reinviteAccepted', self);
         });

--- a/test/spec/WebRTC/Simple.spec.js
+++ b/test/spec/WebRTC/Simple.spec.js
@@ -22,19 +22,28 @@ describe('WebRTC/Simple', function() {
       }
     });
     expect(simple).toBeTruthy();
-    expect(simple.ua.configuration).toEqual({
+
+    var expected = {
       authorizationUser: undefined,
       displayName: undefined,
       password: undefined,
       register: true,
       sessionDescriptionHandlerFactoryOptions: {
-        // FIXME: phantomjs is detected as safari!
-        modifiers: [SIP.WebRTC.Modifiers.stripG722]
       },
       traceSip: undefined,
       uri: 'bob@example.com',
       userAgentString: undefined,
       wsServers: ['wss://sip-ws.example.com'],
-    });
+    }
+
+    // FIXME: phantomjs is detected as safari!
+    var browserUa = navigator.userAgent.toLowerCase();
+    if (browserUa.indexOf('safari') > -1 && browserUa.indexOf('chrome') < 0) {
+      expected.sessionDescriptionHandlerFactoryOptions = {
+        modifiers: [SIP.WebRTC.Modifiers.stripG722],
+      }
+    }
+
+    expect(simple.ua.configuration).toEqual(expected);
   });
 });


### PR DESCRIPTION
Previously SIP.js would send a BYE but the client code would never be notified of that, so the UI would basically not be able to recover.

While I was at it I also fixed the WebRTC.Simple test on non-Safari browsers, to avoid keeping a false positive.