### PR TITLE
Remove redundant track during renegotiation

### DIFF
--- a/src/WebRTC/SessionDescriptionHandler.js
+++ b/src/WebRTC/SessionDescriptionHandler.js
@@ -14,7 +14,7 @@ module.exports = function (SIP) {
 var SessionDescriptionHandler = function(session, observer, options) {
   // TODO: Validate the options
   this.options = options || {};
-
+  this.initialTrack = null;
   this.logger = session.ua.getLogger('sip.invitecontext.sessionDescriptionHandler', session.id);
   this.session = session;
   this.observer = observer;
@@ -162,8 +162,11 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
           streams = [].concat(streams);
           streams.forEach(function (stream) {
             if (self.peerConnection.addTrack) {
+              if (self.initialTrack) {
+                self.peerConnection.removeTrack(self.initialTrack);
+              }
               stream.getTracks().forEach(function (track) {
-                self.peerConnection.addTrack(track, stream);
+                self.initialTrack = self.peerConnection.addTrack(track, stream);
               });
             } else {
               // Chrome 59 does not support addTrack


### PR DESCRIPTION
After renegotiation by reinvite two audio tracks remains active, because it add new track to peerConnection but never removes the old one. This commit removes redundant track