### PR TITLE
Add P-Asserted-Identity header support

### DIFF
--- a/src/ServerContext.js
+++ b/src/ServerContext.js
@@ -24,6 +24,9 @@ ServerContext = function (ua, request) {
 
   this.localIdentity = request.to;
   this.remoteIdentity = request.from;
+  if (request.hasHeader('P-Asserted-Identity')) {
+    this.assertedIdentity = new SIP.NameAddrHeader.parse(request.getHeader('P-Asserted-Identity'));
+  }
 };
 
 ServerContext.prototype = Object.create(SIP.EventEmitter.prototype);

--- a/src/Session.js
+++ b/src/Session.js
@@ -378,6 +378,10 @@ Session.prototype = {
 
     self.emit('reinvite', this);
 
+    if (request.hasHeader('P-Asserted-Identity')) {
+      this.assertedIdentity = new SIP.NameAddrHeader.parse(request.getHeader('P-Asserted-Identity'));
+    }
+
     // Invite w/o SDP
     if (request.getHeader('Content-Length') === '0' && !request.getHeader('Content-Type')) {
       promise = this.sessionDescriptionHandler.getDescription(this.sessionDescriptionHandlerOptions, this.modifiers);
@@ -1533,6 +1537,10 @@ InviteClientContext.prototype = {
 
         this.status = C.STATUS_1XX_RECEIVED;
 
+        if (response.hasHeader('P-Asserted-Identity')) {
+          this.assertedIdentity = new SIP.NameAddrHeader.parse(response.getHeader('P-Asserted-Identity'));
+        }
+
         if(response.hasHeader('require') &&
            response.getHeader('require').indexOf('100rel') !== -1) {
 
@@ -1623,6 +1631,10 @@ InviteClientContext.prototype = {
         var cseq = this.request.cseq + ' ' + this.request.method;
         if (cseq !== response.getHeader('cseq')) {
           break;
+        }
+
+        if (response.hasHeader('P-Asserted-Identity')) {
+          this.assertedIdentity = new SIP.NameAddrHeader.parse(response.getHeader('P-Asserted-Identity'));
         }
 
         if (this.status === C.STATUS_EARLY_MEDIA && this.dialog) {


### PR DESCRIPTION
RFC 3325 indicates:
Typically, a user agent renders the value of a P-Asserted-Identity
header field that it receives to its user.  It may consider the identity
provided by a Trust Domain to be privileged, or intrinsically more
trustworthy than the From header field of a request.  However, any
specific behavior is specific to implementations or services.

The header has been added so that UA's can use it instead of the
remoteIdentity if this behavior is required.

Polycom, SNOM, Bria, Ekiga                                                                                                                                            render the P-Asserted-Identity header if they receive it during a
reINVITE, or in a 1xx/2xx response.
