### PR TITLE
Fix Modifiers that strip RTP payloads

### DIFF
--- a/src/Web/Modifiers.js
+++ b/src/Web/Modifiers.js
@@ -32,9 +32,6 @@ Modifiers = {
       for (var i = 3; i < mline.length; i=i+1) {
         if (mline[i] === "9") {
           mline.splice(i, 1);
-          var numberOfCodecs = parseInt(mline[1], 10);
-          numberOfCodecs = numberOfCodecs - 1;
-          mline[1] = numberOfCodecs.toString();
         }
       }
       mline = mline.join(" ");

--- a/src/Web/Modifiers.js
+++ b/src/Web/Modifiers.js
@@ -7,6 +7,51 @@
 module.exports = function(SIP) {
 var Modifiers;
 
+function stripPayload(sdp, payload) {
+  var i;
+  var media_descs = [];
+  var current_media_desc;
+
+  var lines = sdp.split(/\r\n/);
+
+  for (i = 0; i < lines.length;) {
+    var line = lines[i];
+    if (/^m=(?:audio|video)/.test(line)) {
+      current_media_desc = {
+        index: i,
+        stripped: []
+      };
+      media_descs.push(current_media_desc);
+    } else if (current_media_desc) {
+      var rtpmap = /^a=rtpmap:(\d+) ([^/]+)\//.exec(line);
+      if (rtpmap && payload === rtpmap[2]) {
+        lines.splice(i, 1);
+        current_media_desc.stripped.push(rtpmap[1]);
+        continue; // Don't increment 'i'
+      }
+    }
+
+    i++;
+  }
+
+  for (i = 0; i < media_descs.length; i++) {
+    var mline = lines[media_descs[i].index].split(' ');
+
+    // Ignore the first 3 parameters of the mline. The codec information is after that
+    for (var j = 3; j < mline.length;) {
+      if (media_descs[i].stripped.indexOf(mline[j]) !== -1) {
+        mline.splice(j, 1);
+        continue;
+      }
+      j++;
+    }
+
+    lines[media_descs[i].index] = mline.join(' ');
+  }
+
+  return lines.join('\r\n');
+}
+
 Modifiers = {
   stripTcpCandidates: function(description) {
     description.sdp = description.sdp.replace(/^a=candidate:\d+ \d+ tcp .*?\r\n/img, "");
@@ -14,7 +59,7 @@ Modifiers = {
   },
 
   stripTelephoneEvent: function(description) {
-    description.sdp = description.sdp.replace(/^a=rtpmap:\d+ telephone-event\/\d+\r\n/img, "");
+    description.sdp = stripPayload(description.sdp, 'telephone-event');
     return SIP.Utils.Promise.resolve(description);
   },
 
@@ -24,21 +69,15 @@ Modifiers = {
   },
 
   stripG722: function(description) {
-    var parts = description.sdp.match(/^m=audio.*$/gm);
-    if (parts) {
-      var mline = parts[0];
-      mline = mline.split(" ");
-      // Ignore the first 3 parameters of the mline. The codec information is after that
-      for (var i = 3; i < mline.length; i=i+1) {
-        if (mline[i] === "9") {
-          mline.splice(i, 1);
-        }
-      }
-      mline = mline.join(" ");
-      description.sdp = description.sdp.replace(/^m=audio.*$/gm, mline);
-      description.sdp = description.sdp.replace(/^a=rtpmap:.*G722\/8000\r\n?/gm, "").replace();
-    }
+    description.sdp = stripPayload(description.sdp, 'G722');
     return SIP.Utils.Promise.resolve(description);
+  },
+
+  stripRtpPayload: function(payload) {
+    return function(description) {
+      description.sdp = stripPayload(description.sdp, payload);
+      return SIP.Utils.Promise.resolve(description);
+    };
   }
 };
 

--- a/test/spec/Web/Modifiers.spec.js
+++ b/test/spec/Web/Modifiers.spec.js
@@ -23,6 +23,7 @@ describe('Web/Modifiers', function () {
     Modifiers.stripTelephoneEvent(sdpWrapper).then(function (description) {
       expect(description.type).toBe('offer');
       expect(description.sdp).not.toContain('a=rtpmap:126 telephone-event/8000');
+      expect(description.sdp).toContain('m=audio 53026 RTP/SAVPF 111 103 104 0 8 106 105 13\r\n');
 
       done();
     });


### PR DESCRIPTION
The first commit in this change set - while overwritten by the second - was left in as a record of a bug that was present in the previous implementation of `Modifiers.stripG722`.