### PR TITLE
Transport: fix loosing context for reconnect timer function

### DIFF
--- a/src/Web/Transport.js
+++ b/src/Web/Transport.js
@@ -338,7 +338,7 @@ Transport.prototype = Object.create(SIP.Transport.prototype, {
         this.disposeWs();
         this.connect();
         this.reconnectTimer = null;
-      }, this.configuration.reconnectionTimeout * 1000);
+      }.bind(this), this.configuration.reconnectionTimeout * 1000);
     }
   }},
 


### PR DESCRIPTION
Fixed reconnect timer error, caused by wrong context.

```
Uncaught TypeError: this.disposeWs is not a function at eval (Transport.js:343)
(anonymous) @ Transport.js:343
setTimeout (async)
Timers.(anonymous function) @ Timers.js:35
reconnect @ Transport.js:342
onClose @ Transport.js:223
```