### PR TITLE
Clear ws before reconnecting

### DIFF
--- a/src/Web/Transport.js
+++ b/src/Web/Transport.js
@@ -325,6 +325,7 @@ Transport.prototype = Object.create(SIP.Transport.prototype, {
       this.logger.log('transport ' + this.server.ws_uri + ' failed | connection state set to \'error\'');
       this.server.isError = true;
       this.emit('transportError');
+      this.disposeWs();
       this.server = this.getNextWsServer();
       this.reconnectionAttempts = 0;
       this.reconnect();


### PR DESCRIPTION
Calling `UA.stop()` when UA is not properly connection throws an exception.

I would expect it to just log "UA already closed" or similar.

Example code:
```
  const ua = new SIP.UA({
    transportOptions: {
      wsServers: ["wss://does.not.exist"],
      maxReconnectionAttempts: 1,
    },
  })
  setTimeout(() => ua.stop(), 2000)
```

> [Transport.js:120](https://github.com/c960657/SIP.js/blob/2038eb8f7a8187401bf2c2140a2dc80d1877fb50/src/Web/Transport.js#L115) Uncaught TypeError: Cannot read property 'ws_uri' of undefined
>   - at Transport.disconnectPromise (Transport.js:120)
>   - at Transport.disconnect (Transport.js:81)
>   - at UA.stop (UA.js:345)
>   - at sip.js:198

I'm not sure about this fix, but it seems that we should reset `this.ws` whenever we change `this.server`.