### PR TITLE
Add missing Max-Forwards header to CANCEL

### DIFF
--- a/src/Transactions.js
+++ b/src/Transactions.js
@@ -288,6 +288,7 @@ InviteClientTransaction.prototype.cancel_request = function(tr, reason, extraHea
   this.cancel += 'To: ' + request.headers['To'].toString() + '\r\n';
   this.cancel += 'From: ' + request.headers['From'].toString() + '\r\n';
   this.cancel += 'Call-ID: ' + request.headers['Call-ID'].toString() + '\r\n';
+  this.cancel += 'Max-Forwards: ' + SIP.UA.C.MAX_FORWARDS + '\r\n';
   this.cancel += 'CSeq: ' + request.headers['CSeq'].toString().split(' ')[0] +
   ' CANCEL\r\n';
 


### PR DESCRIPTION
According to RFC3261  Max-Forward header has to be included in all requests: 

8.1.1 Generating the Request

   A valid SIP request formulated by a UAC MUST, at a minimum, contain
   the following header fields: To, From, CSeq, Call-ID, Max-Forwards,
   and Via; all of these header fields are mandatory in all SIP
   requests.
