### PR TITLE
Update webpack-cli to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "pegjs-loader": "^0.5.4",
     "phantomjs-polyfill-object-assign": "0.0.2",
     "uglifyjs-webpack-plugin": "^1.2.5",
-    "webpack": "^4.8.3",
-    "webpack-cli": "^2.1.3"
+    "webpack": "^4.16.0",
+    "webpack-cli": "^3.0.8"
   },
   "engines": {
     "node": ">=6.0"


### PR DESCRIPTION
Installing an old version of webpack-cli drags in babel-preset-es2015,
which gives us a warning. I was initially confused by the warning as
SIP.js itself has migrated to babel-preset-env.