### PR TITLE
Reset keep-alive debounce timer

### DIFF
--- a/src/Web/Transport.js
+++ b/src/Web/Transport.js
@@ -438,6 +438,7 @@ Transport.prototype = Object.create(SIP.Transport.prototype, {
     }
 
     this.keepAliveDebounceTimeout = SIP.Timers.setTimeout(function() {
+      this.clearKeepAliveTimeout();
       this.emit('keepAliveDebounceTimeout');
     }.bind(this), this.configuration.keepAliveDebounce * 1000);
 


### PR DESCRIPTION
The keep-alive debounce timer is never reset, so only one keep-alive is ever sent.