### PR TITLE
Check if transportConstructor type is 'function'

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -1071,7 +1071,7 @@ UA.prototype.getConfigurationCheck = function () {
       },
 
       transportConstructor: function(transportConstructor) {
-        if (typeof transportConstructor === Function) {
+        if (typeof transportConstructor === 'function') {
           return transportConstructor;
         }
       },


### PR DESCRIPTION
Instead of checking if it's `Function`, because without this commit not even the default `transportConstructor` would be considered valid (because its type is `'function'`).

Example:

```js
var userAgent = new SIP.UA({ uri: '1000@mazuh-server', password: '1234' });

typeof userAgent.configuration.transportConstructor === Function // FALSE
typeof userAgent.configuration.transportConstructor === 'function' // TRUE
```

I found it while I was trying to create my own Transport, which should be possible since 0.11.X.