### PR TITLE
Allow specifying second argument for RTCPeerConnection constructor

### DIFF
--- a/src/Web/SessionDescriptionHandler.js
+++ b/src/Web/SessionDescriptionHandler.js
@@ -382,6 +382,7 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
     options = options || {};
     options = this.addDefaultIceCheckingTimeout(options);
     options.rtcConfiguration = options.rtcConfiguration || {};
+    options.rtcConstraints = options.rtcConstraints || {};
     options.rtcConfiguration = this.addDefaultIceServers(options.rtcConfiguration);
 
     this.logger.log('initPeerConnection');
@@ -392,7 +393,7 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
       this.peerConnection.close();
     }
 
-    this.peerConnection = new this.WebRTC.RTCPeerConnection(options.rtcConfiguration);
+    this.peerConnection = new this.WebRTC.RTCPeerConnection(options.rtcConfiguration, options.rtcConstraints);
 
     this.logger.log('New peer connection created');
 


### PR DESCRIPTION
The constructor RTCPeerConnection takes a second argument. This is deprecated (if it was ever in the spec), but AFAICT this is the only way to pass vendor-specific constrains supported by Chrome, such as `googDscp`and `googIPv6`.

In particular I am interested in enabling DSCP, but passing `googDscp` as a constraint in any other way does not seem to have any effect.