### PR TITLE
Grammar: Accept 'IPv6reference' for Via received parameter

### DIFF
--- a/src/Grammar/src/Grammar.pegjs
+++ b/src/Grammar/src/Grammar.pegjs
@@ -813,7 +813,7 @@ via_ttl           = "ttl"i EQUAL via_ttl_value: ttl {
 via_maddr         = "maddr"i EQUAL via_maddr: host {
                       options.data.maddr = via_maddr; }
 
-via_received      = "received"i EQUAL via_received: (IPv4address / IPv6address) {
+via_received      = "received"i EQUAL via_received: (IPv4address / IPv6address / IPv6reference) {
                       options.data.received = via_received; }
 
 via_branch        = "branch"i EQUAL via_branch: token {


### PR DESCRIPTION
When Asterisk generates a Via header where the received parameter is an IPv6 address, the address is being enclosed in square brackets. While this is technically incorrect according to RFC 3261, RFC 5118 suggests that UAs accept it both with and without the enclosing brackets:

https://tools.ietf.org/html/rfc5118#section-4.5

Fixes #582