### PR TITLE
ICE gathering complete detection for old browsers

### DIFF
--- a/src/Web/SessionDescriptionHandler.js
+++ b/src/Web/SessionDescriptionHandler.js
@@ -410,10 +410,14 @@ SessionDescriptionHandler.prototype = Object.create(SIP.SessionDescriptionHandle
       };
     }
 
-    this.peerConnection.onicecandidate = function(e) {
+    this.peerConnection.onicecandidate = function (e) {
       self.emit('iceCandidate', e);
       if (e.candidate) {
-        self.logger.log('ICE candidate received: '+ (e.candidate.candidate === null ? null : e.candidate.candidate.trim()));
+        self.logger.log('ICE candidate received: ' + (e.candidate.candidate === null ? null : e.candidate.candidate.trim()));
+      } else if (e.candidate === null) {
+        // indicates the end of candidate gathering
+        self.logger.log('ICE candidate gathering complete');
+        self.triggerIceGatheringComplete();
       }
     };
 


### PR DESCRIPTION
`onicegatheringstatechange ` event implemented in chrome 59+ [MDN](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/onicegatheringstatechange#Browser_compatibility) and firefox 53+ [(bug)](https://bugzilla.mozilla.org/show_bug.cgi?id=1193731)

`triggerIceGatheringComplete` never executed in old browsers, and invite does not sended.

I made fallback with with `onicecandidate` [MDN](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/onicecandidate) : 

> If the event's candidate property is null, ICE gathering has finished.