### PR TITLE
Transport: Accept multiple CRLFs as a keep alive packet

### DIFF
--- a/src/Web/Transport.js
+++ b/src/Web/Transport.js
@@ -275,7 +275,7 @@ Transport.prototype = Object.create(SIP.Transport.prototype, {
   onMessage: {writable: true, value: function onMessage (e) {
     var data = e.data;
     // CRLF Keep Alive response from server. Clear our keep alive timeout.
-    if(data === '\r\n') {
+    if (/^(\r\n)+$/.test(data)) {
       this.clearKeepAliveTimeout();
 
       if (this.configuration.traceSip === true) {


### PR DESCRIPTION
Use a regular expression to match 1 or more CRLF pairs for a keep alive packet instead of requiring it to be a single CRLF pair.

If configured, Asterisk will always send a double CRLF for keep alives, regardless of what the client is doing.