### PR TITLE
Initial Steps Towards TypeScript (community input requested)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "javascript"
   ],
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
-    "babel-preset-env": "^1.6.1",
+    "awesome-typescript-loader": "^5.2.1",
     "eslint": "^5.4.0",
     "jasmine-core": "^3.2.1",
     "karma": "^3.0.0",
@@ -40,6 +38,7 @@
     "karma-webpack": "^3.0.0",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.4",
+    "typescript": "^3.0.3",
     "webpack": "^4.19.0",
     "webpack-cli": "^3.0.8"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "outDir": "./dist",
+        "allowJs": true,
+        "target": "es5"
+    },
+    "include": [
+        "./src/**/*"
+    ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,10 +61,7 @@ module.exports = function (env) {
         {
           test: /\.js$/,
           exclude: /node_modules/,
-          loader: "babel-loader",
-          options: {
-            presets: ['env']
-          }
+          loader: "awesome-typescript-loader"
         },
         {
           test: /\.pegjs$/,


### PR DESCRIPTION
Hi,
  Internally at OnSIP we've transitioned all of our web-based projects to typescript, with a lot of success. We've been wrapping SIP.js in order to type the inputs and outputs, but believe it would be beneficial to open-source this aspect of the work, both for us and for SIP.js users.

  The initial change outlined here is minor. It is just replacing babel with typescript for our transpiling, and adding the tsconfig targeting es5. I'd be curious to hear from @jlaine here, as he introduced babel to start transpiling SIP.js, but there should be no ill effect.

One difference I did notice, the unminified dist file is 55KB larger. Upon investigating, it appears typescript forces an indent of 4 spaces (we use 2), which adds a lot of white space. They do not have a way to configure this, and explain that formatting options is a lot of added work, and as long as it's human readable it's fine, Size concerns really only come into play with minified files (The minified size has not changed). This seems like a reasonable change, and any of our users with size concerns can either minify themselves, which is expected (we point our node package to the unminified dist for this reason), or use our minified dist.

From here, there would be a fairly slow transition to full type coverage for our app. Changing all of our extensions to .ts would be a pretty quick change right after this, with no code change besides that. Once we get there, we could begin turning on and enforcing ts rules, which would provide some fairly fast benefits. We would likely allow coding to es7, and move that forward as the standard permits, with a target of es5.

Does anybody have any thoughts on this? We'll let this sit for a week or two, in case there are any concerns or questions.

Thanks,
James