### PR TITLE
Support GUID custom domain

### DIFF
--- a/src/Grammar/src/Grammar.pegjs
+++ b/src/Grammar/src/Grammar.pegjs
@@ -140,7 +140,8 @@ hostname        = ( domainlabel "." )* toplabel  "." ? {
 
 domainlabel     = domainlabel: ( [a-zA-Z0-9_-]+ )
 
-toplabel        = toplabel: ( [a-zA-Z][a-zA-Z0-9-]* )
+// D2Nova Stephen Chen: support GUID format domain
+toplabel        = toplabel: ( [a-zA-Z0-9][a-zA-Z0-9-]* )
 
 IPv6reference   = "[" IPv6address "]" {
                     options.data.host_type = 'IPv6';

--- a/src/UA.js
+++ b/src/UA.js
@@ -800,6 +800,8 @@ UA.prototype.loadConfig = function(configuration) {
 
       uri: new SIP.URI('sip', 'anonymous.' + SIP.Utils.createRandomToken(6), 'anonymous.invalid', null, null),
 
+      domain: null,
+
       //Custom Configuration Settings
       custom: {},
 
@@ -950,6 +952,12 @@ UA.prototype.loadConfig = function(configuration) {
   hostportParams.user = null;
   settings.hostportParams = hostportParams.toRaw().replace(/^sip:/i, '');
 
+  // D2Nova Stephen Chen: customize the domain
+  if (settings.domain) {
+    settings.uri.host = settings.domain;
+    settings.uri.port = '';
+  }
+
   /* Check whether authorizationUser is explicitly defined.
    * Take 'settings.uri.user' value if not.
    */
@@ -1067,6 +1075,12 @@ UA.prototype.getConfigurationCheck = function () {
           return;
         } else {
           return parsed;
+        }
+      },
+      // D2Nova Stephen Chen: validate the domain via Grammar parsing.
+      domain: function(domain) {
+        if (domain && typeof domain === 'string' && SIP.Grammar.parse(domain, 'host') !== -1) {
+          return domain;
         }
       },
 


### PR DESCRIPTION
-Change the Grammar parsing to support GUID domain
-Add UA configuration 'domain' to support custom domain

To support a sip user uri like:
sip:stephen@6e88cfa0-07f0-4ba1-be83-a06cdb9e454f

outbound proxy:
proxy.my.domain:9999

```
user = 'stephen';
domain = '6e88cfa0-07f0-4ba1-be83-a06cdb9e454f';
outboundProxy = 'proxy.my.domain:9999';

const config = {
            domain: domain,
            uri: 'sip:' + user + '@' + outboundProxy,
            transportOptions: {
                wsServers: [wsServerURL],
              },
            contactName: user,
            authorizationUser: user,
            password: password,
          };
```

D2Nova Stephen Chen