### PR TITLE
Transport: Allow infinite reconnection

### DIFF
--- a/src/Web/Transport.js
+++ b/src/Web/Transport.js
@@ -337,10 +337,15 @@ Transport.prototype = Object.create(SIP.Transport.prototype, {
     }
 
     if (this.noAvailableServers()) {
-      this.logger.warn('no available ws servers left - going to closed state');
       this.status = C.STATUS_CLOSED;
       this.resetServerErrorStatus();
-      return;
+      if (!this.configuration.alwaysReconnect) {
+        this.logger.warn('no available ws servers left - going to closed state');
+        return;
+      }
+      this.logger.warn('no available ws servers left - restarting');
+      this.reconnectionAttempts = 0;
+      this.server = this.getNextWsServer();
     }
 
     if (this.isConnected()) {
@@ -547,6 +552,7 @@ Transport.prototype = Object.create(SIP.Transport.prototype, {
 
         connectionTimeout: 5,
 
+        alwaysReconnect: true,
         maxReconnectionAttempts: 3,
         reconnectionTimeout: 4,
 
@@ -730,6 +736,12 @@ Transport.prototype = Object.create(SIP.Transport.prototype, {
         traceSip: function(traceSip) {
           if (typeof traceSip === 'boolean') {
             return traceSip;
+          }
+        },
+
+        alwaysReconnect: function(alwaysReconnect) {
+          if (typeof alwaysReconnect === 'boolean') {
+            return alwaysReconnect;
           }
         },
 


### PR DESCRIPTION
The current behavior is to try each server a given number of times
depending on the maxReconnectionAttempts, then fail permanently.

We could have network situations where the softphone is disconnected
from the Internet. Users expect the softphone to come back online as
soon as possible without the need to reload. That is also a standard
bevhaviour among hardware IP Phones and other softphones.

This is achieved thanks to this patch and the introduction of the
alwaysReconnect parameter.