### PR TITLE
Add some more type definitions

### DIFF
--- a/types/SIP.d.ts
+++ b/types/SIP.d.ts
@@ -5,6 +5,7 @@ import { NameAddrHeader } from "./name-addr-header";
 export * from "./session";
 export * from "./session-description-handler";
 export * from "./session-description-handler-factory";
+export * from "./subscription";
 export * from "./ua";
 export * from "./uri";
 export * from "./Web"

--- a/types/SIP.d.ts
+++ b/types/SIP.d.ts
@@ -2,6 +2,7 @@ import { UA } from "./ua";
 import { IncomingMessage } from "http";
 import { NameAddrHeader } from "./name-addr-header";
 
+export * from "./name-addr-header";
 export * from "./session";
 export * from "./session-description-handler";
 export * from "./session-description-handler-factory";

--- a/types/Web/session-description-handler.d.ts
+++ b/types/Web/session-description-handler.d.ts
@@ -1,6 +1,8 @@
 import {SessionDescriptionHandler, SessionDescriptionHandlerModifiers, SessionDescriptionHandlerOptions} from "../session-description-handler";
 
 export class WebSessionDescriptionHandler implements SessionDescriptionHandler {
+  peerConnection: RTCPeerConnection;  // peer connection is created in constructor, and never unset
+
   close(): void;
   getDescription(options?: WebSessionDescriptionHandlerOptions, modifiers?: SessionDescriptionHandlerModifiers): Promise<{ body: string; contentType: string }>;
   hasDescription(contentType: string): boolean;

--- a/types/session.d.ts
+++ b/types/session.d.ts
@@ -79,6 +79,9 @@ export namespace Session {
 }
 
 export class InviteClientContext extends Session {
+  constructor(ua: UA, target: URI | string, options?: any, modifiers?: any);
+  invite();
+
   cancel(options?: any): Session;
 
   on(name: 'referRequested', callback: (context: ReferServerContext) => void): this;

--- a/types/session.d.ts
+++ b/types/session.d.ts
@@ -12,6 +12,7 @@ export class Session extends EventEmitter {
 
   data?: any; // This is actually an any
   endTime?: Date;
+  assertedIdentity?: NameAddrHeader;
   localIdentity?: NameAddrHeader;
   remoteIdentity?: NameAddrHeader;
   method?: string;

--- a/types/subscription.d.ts
+++ b/types/subscription.d.ts
@@ -1,0 +1,20 @@
+import { EventEmitter } from "events";
+
+export interface Notification {
+  request: any;
+}
+
+/**
+  * The Subscription interface SIP.js is providing.
+  */
+export class Subscription extends EventEmitter {
+
+  refresh(): void;
+  unsubscribe(): void;
+  close(): void;
+
+  on(name: 'accepted', callback: (response: any, cause: C.causes) => void): this;
+  on(name: 'failed' | 'rejected', callback: (response?: any, cause?: C.causes) => void): this;
+  on(name: 'terminated', callback: (message?: any, cause?: C.causes) => void): this;
+  on(name: 'notify', callback: (notification: Notification) => void): this;
+}

--- a/types/ua.d.ts
+++ b/types/ua.d.ts
@@ -2,6 +2,7 @@ import { C, InviteServerContext, ReferServerContext } from ".";
 import { InviteClientContext, Session } from "./session";
 import { SessionDescriptionHandlerFactory, SessionDescriptionHandlerFactoryOptions} from "./session-description-handler-factory";
 import { SessionDescriptionHandlerOptions, SessionDescriptionHandlerModifiers } from "./session-description-handler";
+import { Subscription } from "./subscription";
 import { URI } from "./uri";
 import { EventEmitter } from "events";
 
@@ -23,7 +24,7 @@ export class UA extends EventEmitter {
 
   request(method: string, target: URI, options?: any): any; //Returns a SIP.ClientContext
 
-  subscribe(target: URI, eventPackage: string, options?: any): any;
+  subscribe(target: URI, eventPackage: string, options?: any): Subscription;
 
   unregister(options?: any): UA;
 


### PR DESCRIPTION
Here are a bunch of type definitions that we need to use SIP.js. Up until now, they were either included in `@typings/sip.js` or we were casting objects to `any`.

Here is a list of the changes:

* add constructor and `invite()` for `InviteClientContext`
    
    While it is debatable whether these are part of the public API or not,
    they are currently the only way to create a new session asynchronously,
    e.g. within a Promise.

* add missing `peerConnection` in `SessionDescriptionHandler`
    
    I set it as a non-optional field, because it is set in the constructor
    and never unset; this makes the using code easier as it removes the
    necessity to check for the `peerConnection` property to be defined.

* add missing `assertedIdentity` field in `Session`

* export `NameAddrHeader` class
    
    This is required to be able to perform such a construct:
    
    ```typescript
    import * as SIP from "sip.js"
    const h = SIP.NameAddrHeader.parse(request.getHeader("Diversion"));
    ```

* add basic type information for `Subscription`
