### PR TITLE
Avoid sending PRACK with undefined rseq value in RAck header

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -1664,7 +1664,7 @@ export class InviteClientContext extends Session implements ClientContext {
         return;
       }
 
-      if (response.getHeader("rseq") > 0) {
+      if (response.getHeader("rseq")) {
         extraHeaders.push("RAck: " + response.getHeader("rseq") + " " + response.getHeader("cseq"));
         this.earlyDialogs[id].pracked.push(response.getHeader("rseq"));
 

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -1664,14 +1664,17 @@ export class InviteClientContext extends Session implements ClientContext {
         return;
       }
 
-      extraHeaders.push("RAck: " + response.getHeader("rseq") + " " + response.getHeader("cseq"));
-      this.earlyDialogs[id].pracked.push(response.getHeader("rseq"));
+      if (response.getHeader("rseq") > 0) {
+        extraHeaders.push("RAck: " + response.getHeader("rseq") + " " + response.getHeader("cseq"));
+        this.earlyDialogs[id].pracked.push(response.getHeader("rseq"));
 
-      this.earlyDialogs[id].sendRequest(this, C.PRACK, {
-        extraHeaders,
-        body: Utils.generateFakeSDP(response.body)
-      });
-      return;
+        this.earlyDialogs[id].sendRequest(this, C.PRACK, {
+          extraHeaders,
+          body: Utils.generateFakeSDP(response.body)
+        });
+        return;
+      }
+
     }
 
     // Proceed to cancellation if the user requested.


### PR DESCRIPTION
Before sending a PRACK it checks that the response.getHeader("rseq") exists before sending out an PRACK. I had scenarios where a PRACK was send with undefined rseq parameter in the RAck header:
RAck: undefined 2641 INVITE

Reported in #672
Could not test the code yet, I am not a javascript nor typescript developer
But feel free to change this.