### PR TITLE
Emit "accepted" on BYE response

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -213,7 +213,9 @@ export abstract class Session extends EventEmitter {
       throw new TypeError("Invalid statusCode: " + statusCode);
     }
 
-    options.receiveResponse = () => { /* empty block */ };
+    options.receiveResponse = (response) => {
+      this.accepted(response);
+    };
 
     return this.sendRequest(C.BYE, options).terminated();
   }


### PR DESCRIPTION
As far as I can see, there is no event when a BYE request is completed.

From the documentation:

> ## accepted
> Fired each time a successful final (200-299) response is received.

This event was not fired on successful responses to BYE.

There is also a `terminated` and a `bye` event, but those are fired when the session is terminating, it does not wait for the BYE response.