### PR TITLE
UA: Allow omitting some logger configuration

### DIFF
--- a/src/UA.ts
+++ b/src/UA.ts
@@ -68,8 +68,8 @@ export namespace UA {
     hostportParams?: any;
     log?: {
       builtinEnabled: boolean,
-      level: string | number,
-      connector: (level: string, category: string, label: string | undefined, content: any) => void,
+      level?: string | number,
+      connector?: (level: string, category: string, label: string | undefined, content: any) => void,
     };
     noAnswerTimeout?: number;
     password?: string;
@@ -200,9 +200,7 @@ export class UA extends EventEmitter {
 
     // Apply log configuration if present
     if (configuration.log) {
-      if (configuration.log.hasOwnProperty("builtinEnabled")) {
-        this.log.builtinEnabled = configuration.log.builtinEnabled;
-      }
+      this.log.builtinEnabled = configuration.log.builtinEnabled;
 
       if (configuration.log.hasOwnProperty("connector")) {
         this.log.connector = configuration.log.connector;


### PR DESCRIPTION
I'm on the fence about making `builtinEnabled` optional, but it seems that if you've defined a `log` property, you will want at least that to be set.