### PR TITLE
Add jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A JavaScript SIP stack for WebRTC, instant messaging, and more!
 
 * [sipjs.com/download](https://sipjs.com/download/)
 * npm: `npm install sip.js`
+* [jsDelivr CDN](https://www.jsdelivr.com/package/npm/sip.js)
 
 ## Authors
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as an easier and faster option of using the project.