### PR TITLE
Fix type of SessionDescriptionHandlerOptions.constraints

### DIFF
--- a/src/session-description-handler.ts
+++ b/src/session-description-handler.ts
@@ -76,7 +76,7 @@ export type SessionDescriptionHandlerModifiers = Array<SessionDescriptionHandler
  */
 export interface SessionDescriptionHandlerOptions {
   modifiers?: SessionDescriptionHandlerModifiers;
-  constraints?: { audio: boolean, video: boolean };
+  constraints?: MediaStreamConstraints;
 }
 
 /**


### PR DESCRIPTION
Elsewhere in the Web SessionDescriptionHandler we assume the constraints property to be of type MediaStreamConstraints, but for historical reasons the SessionDescriptionHandlerOptions property had a custom interface type.

This made it difficult to cast options because the Typescript compiler would complain on such construct:

```
  const constraints: MediaStreamConstraints = {
    audio: true,
    video: false,
  }

  const options: SessionDescriptionHandlerOptions = { constraints }
```

The raised error was:

```
  ERROR TS2345: Argument of type '{ sessionDescriptionHandlerOptions:{ constraints: MediaStreamConstraints; }; }' is not assignable to parameter of type 'Options'.
  Types of property 'sessionDescriptionHandlerOptions' are incompatible.
    Type '{ constraints: MediaStreamConstraints; }' is not assignable to type 'SessionDescriptionHandlerOptions'.
      Types of property 'constraints' are incompatible.
        Type 'MediaStreamConstraints' is not assignable to type '{ audio: boolean; video: boolean; }'.
          Types of property 'audio' are incompatible.
            Type 'boolean | MediaTrackConstraints | undefined' is not assignable to type 'boolean'.
              Type 'undefined' is not assignable to type 'boolean'.
```

Since `MediaStreamConstraints` is more permissive than the previous type `{ audio: boolean, video: boolean }`, it should not break existing code.