### PR TITLE
Fixing issue when sending 0 as integer in dtmf.

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -51,6 +51,7 @@ import {
 } from "./session-description-handler";
 import { SessionDescriptionHandlerFactory } from "./session-description-handler-factory";
 import { DTMF } from "./Session/DTMF";
+import { DTMFValidator } from "./Session/DTMFValidator";
 import { UA } from "./UA";
 import { Utils } from "./Utils";
 
@@ -161,10 +162,8 @@ export abstract class Session extends EventEmitter {
       throw new Exceptions.InvalidStateError(this.status);
     }
 
-    // Check tones
-    if ((!tones && tones !== 0) || !tones.toString().match(/^[0-9A-D#*,]+$/i)) {
-      throw new TypeError("Invalid tones: " + tones);
-    }
+    // Check tones' validity
+    DTMFValidator.checkTonesValidity(tones);
 
     const sendDTMF: () => void = (): void => {
       if (this.status === SessionStatus.STATUS_TERMINATED || !this.tones || this.tones.length === 0) {

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -162,7 +162,7 @@ export abstract class Session extends EventEmitter {
     }
 
     // Check tones
-    if (!tones || !tones.toString().match(/^[0-9A-D#*,]+$/i)) {
+    if ((!tones && tones !== 0) || !tones.toString().match(/^[0-9A-D#*,]+$/i)) {
       throw new TypeError("Invalid tones: " + tones);
     }
 

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -163,7 +163,7 @@ export abstract class Session extends EventEmitter {
     }
 
     // Check tones' validity
-    DTMFValidator.checkTonesValidity(tones);
+    DTMFValidator.validate(tones);
 
     const sendDTMF: () => void = (): void => {
       if (this.status === SessionStatus.STATUS_TERMINATED || !this.tones || this.tones.length === 0) {

--- a/src/Session/DTMF.ts
+++ b/src/Session/DTMF.ts
@@ -37,9 +37,11 @@ export class DTMF extends EventEmitter {
     this.logger = session.ua.getLogger("sip.invitecontext.dtmf", session.id);
     this.owner = session;
 
+    const moreThanOneTone = false;
+
     // If tone is invalid, it will automatically generate an exception.
     // Otherwise, it will return the tone in the correct format.
-    this.tone = DTMFValidator.checkTonesValidity(tone);
+    this.tone = DTMFValidator.validate(tone, moreThanOneTone);
 
     let duration: any = options.duration;
     let interToneGap: any = options.interToneGap;

--- a/src/Session/DTMF.ts
+++ b/src/Session/DTMF.ts
@@ -6,6 +6,7 @@ import { SessionStatus, TypeStrings } from "../Enums";
 import { Exceptions } from "../Exceptions";
 import { Session } from "../Session";
 import { Utils } from "../Utils";
+import { DTMFValidator } from "./DTMFValidator";
 
 /**
  * @class DTMF
@@ -36,21 +37,9 @@ export class DTMF extends EventEmitter {
     this.logger = session.ua.getLogger("sip.invitecontext.dtmf", session.id);
     this.owner = session;
 
-    // Check tone type
-    if (typeof tone === "string" ) {
-      tone = tone.toUpperCase();
-    } else if (typeof tone === "number") {
-      tone = tone.toString();
-    } else {
-      throw new TypeError("Invalid tone: " + tone);
-    }
-
-    // Check tone value
-    if (!tone.match(/^[0-9A-D#*]$/)) {
-      throw new TypeError("Invalid tone: " + tone);
-    } else {
-      this.tone = tone;
-    }
+    // If tone is invalid, it will automatically generate an exception.
+    // Otherwise, it will return the tone in the correct format.
+    this.tone = DTMFValidator.checkTonesValidity(tone);
 
     let duration: any = options.duration;
     let interToneGap: any = options.interToneGap;

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -17,6 +17,6 @@ export class DTMFValidator {
   }
 
   private static generateInvalidToneError(tone: string): void {
-    throw new TypeError("Invalid tone(s): " + tone.toLowerCase());
+    throw new TypeError("Invalid tone(s): " + !!tone ? tone.toLowerCase() : tone);
   }
 }

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -17,6 +17,6 @@ export class DTMFValidator {
   }
 
   private static generateInvalidToneError(tone: string): void {
-    throw new TypeError("Invalid tone(s): " + !!tone ? tone.toLowerCase() : tone);
+    throw new TypeError("Invalid tone(s): " + (!!tone ? tone.toLowerCase() : tone));
   }
 }

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -19,6 +19,7 @@ export class DTMFValidator {
   }
 
   private static generateInvalidToneError(tone: any): void {
-    throw new TypeError("Invalid tone(s): " + (!!tone && typeof tone !== 'boolean' ? tone.toString().toLowerCase() : tone));
+    const toneForMsg: string = (!!tone && typeof tone !== "boolean" ? tone.toString().toLowerCase() : tone);
+    throw new TypeError(`Invalid tone(s): ${toneForMsg}`);
   }
 }

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -1,0 +1,17 @@
+export class DTMFValidator {
+  public static checkTonesValidity(tone: string | number): string {
+    // Check tone type
+    if (typeof tone === "string" ) {
+      tone = tone.toUpperCase();
+    } else if (typeof tone === "number") {
+      tone = tone.toString();
+    } else {
+      throw new TypeError("Invalid tone: " + tone);
+    }
+    // Check tone value
+    if (!tone.match(/^[0-9A-D#*]$/)) {
+      throw new TypeError("Invalid tone: " + tone);
+    }
+    return tone;
+  }
+}

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -11,7 +11,7 @@ export class DTMFValidator {
 
     const regex = moreThanOneTone ? /^[0-9A-D#*,]+$/i : /^[0-9A-D#*]$/i;
     // Check tone value
-    if (!tone.match(regex)) {
+    if (!!tone && !tone.match(regex)) {
       DTMFValidator.generateInvalidToneError(tone);
     }
     return tone;

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -17,6 +17,6 @@ export class DTMFValidator {
   }
 
   private static generateInvalidToneError(tone: string): void {
-    throw new TypeError("Invalid tone(s): " + (!!tone ? tone.toLowerCase() : tone));
+    throw new TypeError("Invalid tone(s): " + (!!tone ? tone.toString().toLowerCase() : tone));
   }
 }

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -1,16 +1,17 @@
 export class DTMFValidator {
-  public static checkTonesValidity(tone: string | number): string {
+  public static validate(tone: string | number, moreThanOneTone: boolean = true): string {
     // Check tone type
     if (typeof tone === "string" ) {
       tone = tone.toUpperCase();
     } else if (typeof tone === "number") {
       tone = tone.toString();
     } else {
-      throw new TypeError("Invalid tones: " + tone);
+      throw new TypeError("Invalid tone(s): " + tone);
     }
+    const regex = moreThanOneTone ? /^[0-9A-D#*,]+$/i : /^[0-9A-D#*]$/i;
     // Check tone value
-    if (!tone.match(/^[0-9A-D#*]$/)) {
-      throw new TypeError("Invalid tones: " + tone);
+    if (!tone.match(regex)) {
+      throw new TypeError("Invalid tone(s): " + tone);
     }
     return tone;
   }

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -1,4 +1,4 @@
-type ToneType = string | number;
+type ToneType = number | string;
 
 export class DTMFValidator {
   public static validate(tone: ToneType, moreThanOneTone: boolean = true): string {
@@ -7,17 +7,18 @@ export class DTMFValidator {
       tone = tone.toUpperCase();
     } else if (typeof tone === "number") {
       tone = tone.toString();
+    } else {
+      DTMFValidator.generateInvalidToneError(tone);
     }
-
     const regex = moreThanOneTone ? /^[0-9A-D#*,]+$/i : /^[0-9A-D#*]$/i;
     // Check tone value
-    if (!!tone && !tone.match(regex)) {
+    if (!tone.match(regex)) {
       DTMFValidator.generateInvalidToneError(tone);
     }
     return tone;
   }
 
-  private static generateInvalidToneError(tone: ToneType): void {
+  private static generateInvalidToneError(tone: any): void {
     throw new TypeError("Invalid tone(s): " + (!!tone && typeof tone !== 'boolean' ? tone.toString().toLowerCase() : tone));
   }
 }

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -6,11 +6,11 @@ export class DTMFValidator {
     } else if (typeof tone === "number") {
       tone = tone.toString();
     } else {
-      throw new TypeError("Invalid tone: " + tone);
+      throw new TypeError("Invalid tones: " + tone);
     }
     // Check tone value
     if (!tone.match(/^[0-9A-D#*]$/)) {
-      throw new TypeError("Invalid tone: " + tone);
+      throw new TypeError("Invalid tones: " + tone);
     }
     return tone;
   }

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -1,13 +1,14 @@
+type ToneType = string | number;
+
 export class DTMFValidator {
-  public static validate(tone: string | number, moreThanOneTone: boolean = true): string {
+  public static validate(tone: ToneType, moreThanOneTone: boolean = true): string {
     // Check tone type
     if (typeof tone === "string" ) {
       tone = tone.toUpperCase();
     } else if (typeof tone === "number") {
       tone = tone.toString();
-    } else {
-      DTMFValidator.generateInvalidToneError(tone);
     }
+
     const regex = moreThanOneTone ? /^[0-9A-D#*,]+$/i : /^[0-9A-D#*]$/i;
     // Check tone value
     if (!tone.match(regex)) {
@@ -16,7 +17,7 @@ export class DTMFValidator {
     return tone;
   }
 
-  private static generateInvalidToneError(tone: string): void {
-    throw new TypeError("Invalid tone(s): " + (!!tone ? tone.toString().toLowerCase() : tone));
+  private static generateInvalidToneError(tone: ToneType): void {
+    throw new TypeError("Invalid tone(s): " + (!!tone && typeof tone !== 'boolean' ? tone.toString().toLowerCase() : tone));
   }
 }

--- a/src/Session/DTMFValidator.ts
+++ b/src/Session/DTMFValidator.ts
@@ -6,13 +6,17 @@ export class DTMFValidator {
     } else if (typeof tone === "number") {
       tone = tone.toString();
     } else {
-      throw new TypeError("Invalid tone(s): " + tone);
+      DTMFValidator.generateInvalidToneError(tone);
     }
     const regex = moreThanOneTone ? /^[0-9A-D#*,]+$/i : /^[0-9A-D#*]$/i;
     // Check tone value
     if (!tone.match(regex)) {
-      throw new TypeError("Invalid tone(s): " + tone);
+      DTMFValidator.generateInvalidToneError(tone);
     }
     return tone;
+  }
+
+  private static generateInvalidToneError(tone: string): void {
+    throw new TypeError("Invalid tone(s): " + tone.toLowerCase());
   }
 }

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -104,6 +104,10 @@ describe('Session', function() {
       expect(function(){Session.dtmf(true);}).toThrowError('Invalid tones: true');
     });
 
+    it('accepts 0 as an integer argument', function() {
+      expect(function(){Session.dtmf(0);}).not.toThrowError('Invalid tones: 0');
+    });
+
     it('accepts a string argument', function() {
       expect(function(){Session.dtmf('1');}).not.toThrowError('Invalid tones: 1');
     });

--- a/test/spec/SpecSession.js
+++ b/test/spec/SpecSession.js
@@ -89,7 +89,7 @@ describe('Session', function() {
     });
 
     it('throws an error if tones is undefined', function() {
-      expect(function(){Session.dtmf(undefined);}).toThrowError('Invalid tones: undefined');
+      expect(function(){Session.dtmf(undefined);}).toThrowError('Invalid tone(s): undefined');
     });
 
     it('throws an error if the session status is incorrect', function() {
@@ -98,18 +98,18 @@ describe('Session', function() {
     });
 
     it('throws an error if tones is the wrong type', function() {
-      expect(function(){Session.dtmf(1);}).not.toThrowError('Invalid tones: 1');
+      expect(function(){Session.dtmf(1);}).not.toThrowError('Invalid tone(s): 1');
       Session.status = 12;
-      expect(function(){Session.dtmf('one');}).toThrowError('Invalid tones: one');
-      expect(function(){Session.dtmf(true);}).toThrowError('Invalid tones: true');
+      expect(function(){Session.dtmf('one');}).toThrowError('Invalid tone(s): one');
+      expect(function(){Session.dtmf(true);}).toThrowError('Invalid tone(s): true');
     });
 
     it('accepts 0 as an integer argument', function() {
-      expect(function(){Session.dtmf(0);}).not.toThrowError('Invalid tones: 0');
+      expect(function(){Session.dtmf(0);}).not.toThrowError('Invalid tone(s): 0');
     });
 
     it('accepts a string argument', function() {
-      expect(function(){Session.dtmf('1');}).not.toThrowError('Invalid tones: 1');
+      expect(function(){Session.dtmf('1');}).not.toThrowError('Invalid tone(s): 1');
     });
 
     xit('throws an error if tone duration is invalid', function() {


### PR DESCRIPTION
I was getting the following error when sending 0 as an integer to the session's dtmf function.

![image](https://user-images.githubusercontent.com/39969633/68601166-2d415900-047a-11ea-8dba-606822e2e9df.png)

Steps to reproduce:
1. Open a voice session, and call session.dtmf(0).
2. Open the browser's console and lookup for the error.

Tested on:
1. Google Chrome Version 78.0.3904.97 (Official Build) (64-bit)
2. Angular 8.2.7
3. SIP.js 0.14.0 (even though, the up to date version contains the same issue).