### PR TITLE
Fix reinvite when using authorizationUser

### DIFF
--- a/src/core/dialogs/dialog.ts
+++ b/src/core/dialogs/dialog.ts
@@ -533,6 +533,16 @@ export class Dialog {
   }
 
   /**
+   * Used to synchronize the local sequence number of a dialog with an
+   * incoming response message. (Used in the case of a re-invite that
+   * goes through 401 authentication).
+   * @param message - Incoming response message to sync local sequence number.
+   */
+  public updateDialogSequenceNumber(message: IncomingResponseMessage): void {
+    this.dialogState.localSequenceNumber = message.cseq;
+  }
+
+  /**
    * If the remote sequence number was not empty, but the sequence number
    * of the request is lower than the remote sequence number, the request
    * is out of order and MUST be rejected with a 500 (Server Internal
@@ -576,15 +586,5 @@ export class Dialog {
       return false;
     }
     return true;
-  }
-
-  /**
-   * Used to synchronize the local sequence number of a dialog with an
-   * incoming response message. (Used in the case of a re-invite that
-   * goes through 401 authentication).
-   * @param message - Incoming response message to sync local sequence number.
-   */
-  public updateDialogSequenceNumber(message: IncomingResponseMessage): void {
-    this.dialogState.localSequenceNumber = message.cseq;
   }
 }

--- a/src/core/dialogs/dialog.ts
+++ b/src/core/dialogs/dialog.ts
@@ -456,7 +456,7 @@ export class Dialog {
     const callId = this.callId;
     let cseq: number;
     if (options && options.cseq) {
-      cseq = options.cseq;
+      cseq = this.dialogState.localSequenceNumber = options.cseq;
     } else if (!this.dialogState.localSequenceNumber) {
       cseq = this.dialogState.localSequenceNumber = 1; // https://tools.ietf.org/html/rfc3261#section-8.1.1.5
     } else {

--- a/src/core/dialogs/dialog.ts
+++ b/src/core/dialogs/dialog.ts
@@ -456,7 +456,7 @@ export class Dialog {
     const callId = this.callId;
     let cseq: number;
     if (options && options.cseq) {
-      cseq = this.dialogState.localSequenceNumber = options.cseq;
+      cseq = options.cseq;
     } else if (!this.dialogState.localSequenceNumber) {
       cseq = this.dialogState.localSequenceNumber = 1; // https://tools.ietf.org/html/rfc3261#section-8.1.1.5
     } else {
@@ -576,5 +576,15 @@ export class Dialog {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Used to synchronize the local sequence number of a dialog with an
+   * incoming response message. (Used in the case of a re-invite that
+   * goes through 401 authentication).
+   * @param message - Incoming response message to sync local sequence number.
+   */
+  public updateDialogSequenceNumber(message: IncomingResponseMessage): void {
+    this.dialogState.localSequenceNumber = message.cseq;
   }
 }

--- a/src/core/user-agents/re-invite-user-agent-client.ts
+++ b/src/core/user-agents/re-invite-user-agent-client.ts
@@ -67,6 +67,9 @@ export class ReInviteUserAgentClient extends UserAgentClient implements Outgoing
         }
         break;
       case /^2[0-9]{2}$/.test(statusCode):
+        // Sync the dialog sequence number in the case of an authorization flow
+        this.dialog.updateDialogSequenceNumber(message);
+
         // Update dialog signaling state with offer/answer in body
         this.dialog.signalingStateTransition(message);
 

--- a/src/core/user-agents/re-invite-user-agent-client.ts
+++ b/src/core/user-agents/re-invite-user-agent-client.ts
@@ -40,6 +40,10 @@ export class ReInviteUserAgentClient extends UserAgentClient implements Outgoing
   }
 
   protected receiveResponse(message: IncomingResponseMessage): void {
+    if (!this.authenticationGuard(message)) {
+      return;
+    }
+
     const statusCode = message.statusCode ? message.statusCode.toString() : "";
     if (!statusCode) {
       throw new Error("Response status code undefined.");


### PR DESCRIPTION
 Currently hold/unhold are not working when using a SIP backend that requires an authorizationUser in the UA configuration. When the reinvite gets sent, it does not have the authorization header set, so the 401 auth flow never happens.

This fix adds the authenticationGuard to the re-invite-user-agent-client receiveMessage method (like the regular invite). Which appears to fix the hold issue.
However, after adding this, unhold failed to work because the cseq was not incrementing correctly. It appeared this was due to the "options.cseq" being passed in to dialog.ts createOutgoingRequestMessage() which did not set the internal localSequenceNumber state, resulting in the same cseq being used for successive messages.

This fix also adds logic to set the localSequenceNumber to the passed in options.cseq which appears to increment it properly.
NOTE: For some reason this second change is causing several unit tests to fail with:
```
Error: Jasmine Clock was unable to install over custom global timer functions. Is the clock already installed?
```
for reasons that are not very clear to me.

Any thoughts on whether this is the appropriate fix for reinvite when using an authorizationUser are welcome, but so far, these couple of changes are working in our setup.

Final note: We are currently using 0.14.6 (waiting for API to stabilize in 0.16), so if this fix gets merged, we'd want to backport it to that version if possible.

Thanks in advance for your feedback.