### PR TITLE
Handle MESSAGE in dialog

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -16,6 +16,7 @@ import {
   IncomingRequestMessage,
   IncomingResponse,
   IncomingResponseMessage,
+  IncomingMessageRequest,
   InviteServerTransaction,
   Logger,
   NameAddrHeader,
@@ -290,6 +291,9 @@ export abstract class Session extends EventEmitter {
         break;
       case C.REFER:
         request = this.session.refer(delegate, requestOptions);
+        break;
+      case C.MESSAGE:
+        request = this.session.message(delegate, requestOptions);
         break;
       default:
         throw new Error(`Unexpected ${method}. Method not implemented by user agent core.`);
@@ -578,6 +582,10 @@ export abstract class Session extends EventEmitter {
         this.emit("notify", incomingRequest.message);
         break;
     }
+  }
+
+  protected receiveMessage(messageRequest: IncomingMessageRequest) {
+    this.emit("onMessage", messageRequest);
   }
 
   // In dialog INVITE Reception
@@ -1043,7 +1051,8 @@ export class InviteServerContext extends Session implements ServerContext {
           onInvite: (inviteRequest): void => this.receiveRequest(inviteRequest),
           onNotify: (notifyRequest): void => this.receiveRequest(notifyRequest),
           onPrack: (prackRequest): void => this.receiveRequest(prackRequest),
-          onRefer: (referRequest): void => this.receiveRequest(referRequest)
+          onRefer: (referRequest): void => this.receiveRequest(referRequest),
+          onMessage: (messageRequest): void => this.receiveMessage(messageRequest),
         };
         this.session = session;
         this.status = SessionStatus.STATUS_WAITING_FOR_ACK;
@@ -1271,6 +1280,10 @@ export class InviteServerContext extends Session implements ServerContext {
         super.receiveRequest(incomingRequest);
         break;
     }
+  }
+
+  protected receiveMessage(messageRequest: IncomingMessageRequest) {
+    this.emit("onMessage", messageRequest);
   }
 
   // Internal Function to setup the handler consistently
@@ -2361,7 +2374,8 @@ export class InviteClientContext extends Session implements ClientContext {
       onInvite: (inviteRequest): void => this.receiveRequest(inviteRequest),
       onNotify: (notifyRequest): void => this.receiveRequest(notifyRequest),
       onPrack: (prackRequest): void => this.receiveRequest(prackRequest),
-      onRefer: (referRequest): void => this.receiveRequest(referRequest)
+      onRefer: (referRequest): void => this.receiveRequest(referRequest),
+      onMessage: (messageRequest): void => this.receiveMessage(messageRequest),
     };
 
     switch (session.signalingState) {

--- a/src/core/session/session-delegate.ts
+++ b/src/core/session/session-delegate.ts
@@ -6,6 +6,7 @@ import {
   IncomingNotifyRequest,
   IncomingPrackRequest,
   IncomingReferRequest,
+  IncomingMessageRequest,
 } from "../messages";
 
 /**
@@ -66,4 +67,10 @@ export interface SessionDelegate {
    * @param request - Incoming REFER request.
    */
   onRefer?(request: IncomingReferRequest): void;
+
+  /**
+   * Receive MESSAGE MESSAGE
+   * @param request - Incoming REFER request.
+   */
+  onMessage?(request: IncomingMessageRequest): void;
 }

--- a/src/core/session/session.ts
+++ b/src/core/session/session.ts
@@ -8,6 +8,7 @@ import {
   OutgoingPrackRequest,
   OutgoingReferRequest,
   OutgoingRequestDelegate,
+  OutgoingMessageRequest,
   RequestOptions,
   URI
 } from "../messages";
@@ -105,6 +106,12 @@ export interface Session {
    * @param options - Options bucket.
    */
   refer(delegate?: OutgoingRequestDelegate, options?: RequestOptions): OutgoingReferRequest;
+  /**
+   * Send MESSAGE request (in dialog).
+   * @param delegate - Request delegate.
+   * @param options - Options bucket.
+   */
+  message(delegate?: OutgoingRequestDelegate, options?: RequestOptions): OutgoingMessageRequest;
 }
 
 /**


### PR DESCRIPTION
This PR aims to be able to send sip `MESSAGE` inside a current dialog.
- [x] Responds to `MESSAGE` with 200 OK
- [x] Add an `onMessage` event on the session when a message is received
- [x] Add a `message` method in SessionDialog to be able to send MESSAGE.

We've used jsSIP in a POC that allows to send this kind of message inside a dialog, and we don't found a way to do it with `Messager`.
