### PR TITLE
Fix ACK re-INVITE race when offer in 200 Ok

### DIFF
--- a/docs/core/sip.js.sessiondelegate.onack.md
+++ b/docs/core/sip.js.sessiondelegate.onack.md
@@ -9,7 +9,7 @@ Receive ACK request.
 <b>Signature:</b>
 
 ```typescript
-onAck?(request: IncomingAckRequest): void;
+onAck?(request: IncomingAckRequest): Promise<void> | void;
 ```
 
 ## Parameters
@@ -20,5 +20,7 @@ onAck?(request: IncomingAckRequest): void;
 
 <b>Returns:</b>
 
-`void`
+`Promise<void> | void`
+
+The callback MUST return a promise if it asynchronously handles answers. For example, an ACK with an answer (offer in the 200 Ok) may require asynchronous processing in which case the callback MUST return a Promise which resolves when the answer handling is complete.
 

--- a/etc/api/sip.js.api.md
+++ b/etc/api/sip.js.api.md
@@ -430,7 +430,7 @@ export abstract class Session {
     // Warning: (ae-forgotten-export) The symbol "IncomingAckRequest" needs to be exported by the entry point index.d.ts
     //
     // @internal
-    protected onAckRequest(request: IncomingAckRequest): void;
+    protected onAckRequest(request: IncomingAckRequest): Promise<void>;
     // @internal
     protected onByeRequest(request: IncomingByeRequest): void;
     // @internal

--- a/etc/core/sip.js.api.md
+++ b/etc/core/sip.js.api.md
@@ -888,7 +888,7 @@ export interface Session {
 
 // @public
 export interface SessionDelegate {
-    onAck?(request: IncomingAckRequest): void;
+    onAck?(request: IncomingAckRequest): Promise<void> | void;
     onAckTimeout?(): void;
     onBye?(request: IncomingByeRequest): void;
     onInfo?(request: IncomingInfoRequest): void;

--- a/src/api/invitation.ts
+++ b/src/api/invitation.ts
@@ -270,7 +270,7 @@ export class Invitation extends Session {
     return this.sendAccept(options)
       .then(({ message, session }) => {
         session.delegate = {
-          onAck: (ackRequest): void => this.onAckRequest(ackRequest),
+          onAck: (ackRequest): Promise<void> => this.onAckRequest(ackRequest),
           onAckTimeout: (): void => this.onAckTimeout(),
           onBye: (byeRequest): void => this.onByeRequest(byeRequest),
           onInfo: (infoRequest): void => this.onInfoRequest(infoRequest),

--- a/src/api/inviter.ts
+++ b/src/api/inviter.ts
@@ -795,7 +795,7 @@ export class Inviter extends Session {
 
     // We have a confirmed dialog.
     session.delegate = {
-      onAck: (ackRequest): void => this.onAckRequest(ackRequest),
+      onAck: (ackRequest): Promise<void> => this.onAckRequest(ackRequest),
       onBye: (byeRequest): void => this.onByeRequest(byeRequest),
       onInfo: (infoRequest): void => this.onInfoRequest(infoRequest),
       onInvite: (inviteRequest): void => this.onInviteRequest(inviteRequest),

--- a/src/core/dialogs/session-dialog.ts
+++ b/src/core/dialogs/session-dialog.ts
@@ -73,6 +73,8 @@ export class SessionDialog extends Dialog implements Session {
 
   /** True if waiting for an ACK to the initial transaction 2xx (UAS only). */
   private ackWait = false;
+  /** True if processing an ACK to the initial transaction 2xx (UAS only). */
+  private ackProcessing = false;
   /** Retransmission timer for 2xx response which confirmed the dialog. */
   private invite2xxTimer: any;
   /** The rseq of the last reliable response. */
@@ -470,7 +472,13 @@ export class SessionDialog extends Dialog implements Session {
       }
       this.signalingStateTransition(message);
       if (this.delegate && this.delegate.onAck) {
-        this.delegate.onAck({ message });
+        const promiseOrVoid = this.delegate.onAck({ message });
+        if (promiseOrVoid instanceof Promise) {
+          this.ackProcessing = true; // make sure this is always reset to false
+          promiseOrVoid
+            .then(() => this.ackProcessing = false)
+            .catch(() => this.ackProcessing = false);
+        }
       }
       return;
     }
@@ -482,7 +490,90 @@ export class SessionDialog extends Dialog implements Session {
       return;
     }
 
+    // Request within a dialog common processing.
+    // https://tools.ietf.org/html/rfc3261#section-12.2.2
+    super.receiveRequest(message);
+
+    // Handle various INVITE related cross-over, glare and race conditions
     if (message.method === C.INVITE) {
+      // Hopefully this message is helpful...
+      const warning = () => {
+        const reason = this.ackWait ? "waiting for initial ACK" : "processing initial ACK";
+        this.logger.warn(`INVITE dialog ${this.id} received re-INVITE while ${reason}`);
+        let msg = "RFC 5407 suggests the following to avoid this race condition... ";
+        msg += " Note: Implementation issues are outside the scope of this document,";
+        msg += " but the following tip is provided for avoiding race conditions of";
+        msg += " this type.  The caller can delay sending re-INVITE F6 for some period";
+        msg += " of time (2 seconds, perhaps), after which the caller can reasonably";
+        msg += " assume that its ACK has been received.  Implementors can decouple the";
+        msg += " actions of the user (e.g., pressing the hold button) from the actions";
+        msg += " of the protocol (the sending of re-INVITE F6), so that the UA can";
+        msg += " behave like this.  In this case, it is the implementor's choice as to";
+        msg += " how long to wait.  In most cases, such an implementation may be";
+        msg += " useful to prevent the type of race condition shown in this section.";
+        msg += " This document expresses no preference about whether or not they";
+        msg += " should wait for an ACK to be delivered.  After considering the impact";
+        msg += " on user experience, implementors should decide whether or not to wait";
+        msg += " for a while, because the user experience depends on the";
+        msg += " implementation and has no direct bearing on protocol behavior.";
+        this.logger.warn(msg);
+        return; // drop re-INVITE request message
+      };
+
+      // A UAS that receives a second INVITE before it sends the final
+      // response to a first INVITE with a lower CSeq sequence number on the
+      // same dialog MUST return a 500 (Server Internal Error) response to the
+      // second INVITE and MUST include a Retry-After header field with a
+      // randomly chosen value of between 0 and 10 seconds.
+      // https://tools.ietf.org/html/rfc3261#section-14.2
+      const retryAfter = Math.floor((Math.random() * 10)) + 1;
+      const extraHeaders = [`Retry-After: ${retryAfter}`];
+
+      // There may be ONLY ONE offer/answer negotiation in progress for a
+      // single dialog at any point in time.  Section 4 explains how to ensure
+      // this.
+      // https://tools.ietf.org/html/rfc6337#section-2.2
+      if (this.ackProcessing) {
+        // UAS-IsI:  While an INVITE server transaction is incomplete or ACK
+        //           transaction associated with an offer/answer is incomplete,
+        //           a UA must reject another INVITE request with a 500
+        //           response.
+        // https://tools.ietf.org/html/rfc6337#section-4.3
+        this.core.replyStateless(message, { statusCode: 500, extraHeaders });
+        warning();
+        return;
+      }
+
+      // 3.1.4.  Callee Receives re-INVITE (Established State)  While in the
+      // Moratorium State (Case 1)
+      // https://tools.ietf.org/html/rfc5407#section-3.1.4
+      // 3.1.5.  Callee Receives re-INVITE (Established State) While in the
+      // Moratorium State (Case 2)
+      // https://tools.ietf.org/html/rfc5407#section-3.1.5
+      if (this.ackWait && this.signalingState !== SignalingState.Stable) {
+        // This scenario is basically the same as that of Section 3.1.4, but
+        // differs in sending an offer in the 200 and an answer in the ACK.  In
+        // contrast to the previous case, the offer in the 200 (F3) and the
+        // offer in the re-INVITE (F6) collide with each other.
+        //
+        // Bob sends a 491 to the re-INVITE (F6) since he is not able to
+        // properly handle a new request until he receives an answer.  (Note:
+        // 500 with a Retry-After header may be returned if the 491 response is
+        // understood to indicate request collision.  However, 491 is
+        // recommended here because 500 applies to so many cases that it is
+        // difficult to determine what the real problem was.)
+        // https://tools.ietf.org/html/rfc5407#section-3.1.5
+
+        // UAS-IsI:  While an INVITE server transaction is incomplete or ACK
+        //           transaction associated with an offer/answer is incomplete,
+        //           a UA must reject another INVITE request with a 500
+        //           response.
+        // https://tools.ietf.org/html/rfc6337#section-4.3
+        this.core.replyStateless(message, { statusCode: 500, extraHeaders });
+        warning();
+        return;
+      }
+
       // A UAS that receives a second INVITE before it sends the final
       // response to a first INVITE with a lower CSeq sequence number on the
       // same dialog MUST return a 500 (Server Internal Error) response to the
@@ -490,9 +581,6 @@ export class SessionDialog extends Dialog implements Session {
       // randomly chosen value of between 0 and 10 seconds.
       // https://tools.ietf.org/html/rfc3261#section-14.2
       if (this.reinviteUserAgentServer) {
-        // https://tools.ietf.org/html/rfc3261#section-20.33
-        const retryAfter = Math.floor((Math.random() * 10)) + 1;
-        const extraHeaders = [`Retry-After: ${retryAfter}`];
         this.core.replyStateless(message, { statusCode: 500, extraHeaders });
         return;
       }
@@ -506,10 +594,6 @@ export class SessionDialog extends Dialog implements Session {
         return;
       }
     }
-
-    // Request within a dialog common processing.
-    // https://tools.ietf.org/html/rfc3261#section-12.2.2
-    super.receiveRequest(message);
 
     // Requests within a dialog MAY contain Record-Route and Contact header
     // fields.  However, these requests do not cause the dialog's route set

--- a/src/core/session/session-delegate.ts
+++ b/src/core/session/session-delegate.ts
@@ -17,8 +17,19 @@ export interface SessionDelegate {
   /**
    * Receive ACK request.
    * @param request - Incoming ACK request.
+   * @returns
+   * The callback MUST return a promise if it asynchronously handles answers.
+   * For example, an ACK with an answer (offer in the 200 Ok) may require
+   * asynchronous processing in which case the callback MUST return a Promise
+   * which resolves when the answer handling is complete.
+   * @privateRemarks
+   * Unlike INVITE handling where we can rely on the generation of a response
+   * to indicate when offer/answer processing has been completed, ACK handling
+   * requires some indication from the handler that answer processing is complete
+   * so that we can avoid some race conditions (see comments in code for more details).
+   * Having the handler return a Promise provides said indication.
    */
-  onAck?(request: IncomingAckRequest): void;
+  onAck?(request: IncomingAckRequest): Promise<void> | void;
 
   /**
    * Timeout waiting for ACK request.

--- a/test/support/api/transport-fake.ts
+++ b/test/support/api/transport-fake.ts
@@ -26,6 +26,7 @@ export class TransportFake extends EventEmitter implements Transport {
   private waitingForReceiveResolve: ResolveFunction | undefined;
   private waitingForReceiveReject: RejectFunction | undefined;
 
+  private _receiveDropOnce = false;
   private _state: TransportState = TransportState.Disconnected;
   private _stateEventEmitter = new EventEmitter();
 
@@ -83,10 +84,17 @@ export class TransportFake extends EventEmitter implements Transport {
     message +=  `Receiving...\n${msg}`;
     // this.logger.log(message);
     this.emit("message", msg);
-    if (this.onMessage) {
+    if (this._receiveDropOnce) {
+      this._receiveDropOnce = false;
+      this.logger.warn((this._id ? `${this._id} ` : "") + "Dropped message");
+    } else if (this.onMessage) {
       this.onMessage(msg);
     }
     this.receiveHappened();
+  }
+
+  public receiveDropOnce(): void {
+    this._receiveDropOnce = true;
   }
 
   public async waitSent(): Promise<void> {

--- a/test/support/core/mocks.ts
+++ b/test/support/core/mocks.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../src/api";
 import {
   DigestAuthentication,
+  IncomingAckRequest,
   IncomingInviteRequest,
   IncomingRequestMessage,
   IncomingResponseMessage,
@@ -143,6 +144,9 @@ export function makeMockSessionDelegate(): jasmine.SpyObj<Required<SessionDelega
     "onPrack",
     "onRefer"
   ]);
+  delegate.onAck.and.callFake((request: IncomingAckRequest) => {
+    return Promise.resolve();
+  });
   return delegate;
 }
 


### PR DESCRIPTION
There is a known race condition where the callee receives re-INVITE (established state) while in the moratorium state (waiting for ACK) which we currently throw an error on (we crash). The race is documented here: https://tools.ietf.org/html/rfc5407#section-3.1.5

It is not something that comes up if the application layer waits for a short period of time (like 2 seconds) before sending a re-INVITE after an ACK as per implementation recommended best practice, but we shouldn't crash regardless.

This fixes it so we respond with a 500 response per the specification.

@james-criscuolo brought this issue to my attention on 1/14.
