### PR TITLE
Prevent invalid state transition in Registerer

### DIFF
--- a/test/spec/api/registration.spec.ts
+++ b/test/spec/api/registration.spec.ts
@@ -72,6 +72,14 @@ describe("API Registration", () => {
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy.calls.argsFor(0)).toEqual([RegistererState.Terminated]);
       });
+
+      it("her registerer should throw if register called", () => {
+        expect(() =>registerer.register()).toThrow();
+      });
+
+      it("her registerer should throw if unregister called", () => {
+        expect(() => registerer.unregister()).toThrow();
+      });
     });
 
     describe("Alice dispose(), dispose()", () => {


### PR DESCRIPTION
The register() method could be called after dispose()
leading to an invalid state transition. One case that is
apparently surprising is that UserAgent.stop() currently
calls Registerer.dispose(), so added a hopefully helpful
error message to explain.

@james-criscuolo brought up the issue on 1/21