### PR TITLE
Fix subscription bugs related to timer N

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -81,6 +81,7 @@ README.md
   Regardless, this needs to wait till post 0.16 as it doesn't make sense to port the old code.
 - Messages (IncomingMessage, OutgoingRequestMessage) could use a make over (tied to Grammar work)
 - Extra headers array approach is error prone
+- Timers and some associated timer code doesn't support unreliable transports (UDP for example)
 
 ### Grammar - Refresh
 - grammar.ts has everything typed as any

--- a/src/api/subscriber.ts
+++ b/src/api/subscriber.ts
@@ -191,7 +191,13 @@ export class Subscriber extends Subscription {
               this._dialog.delegate = {
                 onNotify: (request) => this.onNotify(request),
                 onRefresh: (request) => this.onRefresh(request),
-                onTerminated: () => this.stateTransition(SubscriptionState.Terminated)
+                onTerminated: () => {
+                  // If a call to unsubscribe will state transition to SubscriptionState.Terminated,
+                  // but we can end up here after that if the NOTIFY never arrives and timer N fires.
+                  if (this.state !== SubscriptionState.Terminated) {
+                    this.stateTransition(SubscriptionState.Terminated)
+                  }
+                }
               };
             }
             this.onNotify(result.success.request);

--- a/src/core/dialogs/subscription-dialog.ts
+++ b/src/core/dialogs/subscription-dialog.ts
@@ -308,6 +308,11 @@ export class SubscriptionDialog extends Dialog implements Subscription {
     }
     this.logger.log(`SUBSCRIBE dialog ${this.id} sending SUBSCRIBE request`);
     const uac = new ReSubscribeUserAgentClient(this, delegate, options);
+    // Abort any outstanding timer (as it would otherwise become guaranteed to terminate us).
+    if (this.N) {
+      clearTimeout(this.N);
+      this.N = undefined;
+    }
     // When refreshing a subscription, a subscriber starts Timer N, set to
     // 64*T1, when it sends the SUBSCRIBE request.
     // https://tools.ietf.org/html/rfc6665#section-4.1.2.2
@@ -538,6 +543,7 @@ export class SubscriptionDialog extends Dialog implements Subscription {
    * https://tools.ietf.org/html/rfc6665#section-4.1.2.2
    */
   private timer_N(): void {
+    this.logger.warn(`Timer N expired for SUBSCRIBE dialog. Timed out waiting for NOTIFY.`);
     if (this.subscriptionState !== SubscriptionState.Terminated) {
       this.stateTransition(SubscriptionState.Terminated);
       this.onTerminated();


### PR DESCRIPTION
- unsubscribing prior to a prior re-subscribe generating a NOTIFY
  was resulting in invalid state transition from Terminated to Terminated
- re-subscribing prior to prior re-subscribe generating a NOTIFY
  was resulting in subscription getting terminated by stray timer N

The first issue was often generating errors, but likely not causing any
functional issues. The second issue was causing functional issues, but
not likely happening very often in practice.

@james-criscuolo brought this issue to my attention on 1/21