### PR TITLE
Fix reliable response handling bug

### DIFF
--- a/src/core/dialogs/session-dialog.ts
+++ b/src/core/dialogs/session-dialog.ts
@@ -703,6 +703,11 @@ export class SessionDialog extends Dialog implements Session {
     }
   }
 
+  /**
+   * Guard against out of order reliable provisional responses and retransmissions.
+   * Returns false if the response should be discarded, otherwise true.
+   * @param message - Incoming response message within this dialog.
+   */
   public reliableSequenceGuard(message: IncomingResponseMessage): boolean {
     const statusCode = message.statusCode;
     if (!statusCode) {
@@ -744,9 +749,7 @@ export class SessionDialog extends Dialog implements Session {
         // initialized to the RSeq header field in the first reliable
         // provisional response received for the initial request.
         // https://tools.ietf.org/html/rfc3262#section-4
-        if (!this.rseq) {
-          this.rseq = rseq;
-        }
+        this.rseq = rseq;
       }
     }
 

--- a/src/core/dialogs/session-dialog.ts
+++ b/src/core/dialogs/session-dialog.ts
@@ -749,7 +749,7 @@ export class SessionDialog extends Dialog implements Session {
         // initialized to the RSeq header field in the first reliable
         // provisional response received for the initial request.
         // https://tools.ietf.org/html/rfc3262#section-4
-        this.rseq = rseq;
+        this.rseq = this.rseq ? this.rseq + 1 : rseq;
       }
     }
 

--- a/src/core/user-agents/invite-user-agent-client.ts
+++ b/src/core/user-agents/invite-user-agent-client.ts
@@ -128,7 +128,7 @@ export class InviteUserAgentClient extends UserAgentClient implements OutgoingIn
           // Guard against out of order reliable provisional responses.
           // Note that this is where the rseq tracking is done.
           if (!earlyDialog.reliableSequenceGuard(message)) {
-            this.logger.warn("1xx INVITE reliable response received out of order, dropping.");
+            this.logger.warn("1xx INVITE reliable response received out of order or is a retransmission, dropping.");
             return;
           }
 

--- a/test/spec/api/session.spec.ts
+++ b/test/spec/api/session.spec.ts
@@ -1747,6 +1747,18 @@ describe("API Session", () => {
           describe("Bob reject()", () => {
             bobReject();
           });
+
+          describe("Bob progress(reliable) ", () => {
+            bobProgressReliable();
+
+            describe("Bob accept()", () => {
+              bobAccept();
+            });
+
+            describe("Bob reject()", () => {
+              bobReject();
+            });
+          });
         });
 
         describe("Bob progress()", () => {
@@ -1770,6 +1782,18 @@ describe("API Session", () => {
             describe("Bob reject()", () => {
               bobReject();
             });
+
+            describe("Bob progress(reliable) ", () => {
+              bobProgressReliable();
+
+              describe("Bob accept()", () => {
+                bobAccept();
+              });
+
+              describe("Bob reject()", () => {
+                bobReject();
+              });
+            });  
           });
         });
       });


### PR DESCRIPTION
For a given request, all reliable provisional responses
after the first 2 were being dropped. The rseq was
not begin tracked properly by the UAC, so fixed that.
Also added a test for it.

Fixes #805