### PR TITLE
Add ha1 authentication option to digest authentication

### DIFF
--- a/src/api/user-agent-options.ts
+++ b/src/api/user-agent-options.ts
@@ -39,6 +39,12 @@ export interface UserAgentOptions {
   allowLegacyNotifications?: boolean;
 
   /**
+   * Authorization ha1.
+   * @defaultValue `""`
+   */
+  authorizationHa1?: string;
+
+  /**
    * Authorization password.
    * @defaultValue `""`
    */

--- a/src/api/user-agent.ts
+++ b/src/api/user-agent.ts
@@ -251,6 +251,7 @@ export class UserAgent {
   private static defaultOptions(): Required<UserAgentOptions> {
     return {
       allowLegacyNotifications: false,
+      authorizationHa1: "",
       authorizationPassword: "",
       authorizationUsername: "",
       autoStart: false,
@@ -664,7 +665,8 @@ export class UserAgent {
           ? this.options.authorizationUsername
           : this.options.uri.user; // if authorization username not provided, use uri user as username
         const password = this.options.authorizationPassword ? this.options.authorizationPassword : undefined;
-        return new DigestAuthentication(this.getLoggerFactory(), username, password);
+        const ha1 = this.options.authorizationHa1 ? this.options.authorizationHa1 : undefined;
+        return new DigestAuthentication(this.getLoggerFactory(), ha1, username, password);
       },
       transportAccessor: () => this.transport
     };

--- a/src/core/messages/digest-authentication.ts
+++ b/src/core/messages/digest-authentication.ts
@@ -17,6 +17,7 @@ export class DigestAuthentication {
   public stale: boolean | undefined;
 
   private logger: Logger;
+  private ha1: string | undefined;
   private username: string | undefined;
   private password: string | undefined;
   private cnonce: string | undefined;
@@ -37,10 +38,16 @@ export class DigestAuthentication {
    * @param username - Username.
    * @param password - Password.
    */
-  constructor(loggerFactory: LoggerFactory, username: string | undefined, password: string | undefined) {
+  constructor(
+    loggerFactory: LoggerFactory,
+    ha1: string | undefined,
+    username: string | undefined,
+    password: string | undefined
+  ) {
     this.logger = loggerFactory.getLogger("sipjs.digestauthentication");
     this.username = username;
     this.password = password;
+    this.ha1 = ha1;
     this.nc = 0;
     this.ncHex = "00000000";
   }
@@ -155,10 +162,13 @@ export class DigestAuthentication {
    * Generate Digest 'response' value.
    */
   private calculateResponse(body?: string): void {
-    let ha2;
+    let ha1, ha2;
 
     // HA1 = MD5(A1) = MD5(username:realm:password)
-    const ha1 = MD5(this.username + ":" + this.realm + ":" + this.password);
+    ha1 = this.ha1;
+    if (ha1 === "" || ha1 === undefined) {
+      ha1 = MD5(this.username + ":" + this.realm + ":" + this.password);
+    }
 
     if (this.qop === "auth") {
       // HA2 = MD5(A2) = MD5(method:digestURI)

--- a/test/support/core/mocks.ts
+++ b/test/support/core/mocks.ts
@@ -250,7 +250,8 @@ export function makeUserAgentCoreConfigurationFromUserAgent(ua: UserAgent): User
         ? ua.configuration.authorizationUsername
         : ua.configuration.uri.user; // if authorization username not provided, use uri user as username
       const password = ua.configuration.authorizationPassword ? ua.configuration.authorizationPassword : undefined;
-      return new DigestAuthentication(ua.getLoggerFactory(), username, password);
+      const ha1 = ua.configuration.authorizationHa1 ? ua.configuration.authorizationHa1 : undefined;
+      return new DigestAuthentication(ua.getLoggerFactory(), ha1, username, password);
     },
     transportAccessor: () => ua.transport
   };


### PR DESCRIPTION
Adds a method of authorising a user with a service by providing SIP.js with an authorisation token instead of password, which marginally helps security-wise. I haven't written any tests because I don't really know how, but I did integrate the ha1 into the exising mock code.