### PR TITLE
Add configuration parameter for automatically sending an initial response

### DIFF
--- a/src/api/invitation.ts
+++ b/src/api/invitation.ts
@@ -187,29 +187,13 @@ export class Invitation extends Session {
   /**
    * If true, a first provisional response after the 100 Trying
    * will be sent automatically. This is false it the UAC required
-   * reliable provisional responses (100rel in Require header),
-   * otherwise it is true. The provisional is sent by calling
-   * `progress()` without any options.
-   *
-   * FIXME: TODO: It seems reasonable that the ISC user should
-   * be able to optionally disable this behavior. As the provisional
-   * is sent prior to the "invite" event being emitted, it's a known
-   * issue that the ISC user cannot register listeners or do any other
-   * setup prior to the call to `progress()`. As an example why this is
-   * an issue, setting `ua.configuration.rel100` to REQUIRED will result
-   * in an attempt by `progress()` to send a 183 with SDP produced by
-   * calling `getDescription()` on a session description handler, but
-   * the ISC user cannot perform any potentially required session description
-   * handler initialization (thus preventing the utilization of setting
-   * `ua.configuration.rel100` to REQUIRED). That begs the question of
-   * why this behavior is disabled when the UAC requires 100rel but not
-   * when the UAS requires 100rel? But ignoring that, it's just one example
-   * of a class of cases where the ISC user needs to do something prior
-   * to the first call to `progress()` and is unable to do so.
-   * @internal
+   * reliable provisional responses (100rel in Require header) or
+   * the user agent configuration has specified to not send an
+   * initial response, otherwise it is true. The provisional is sent by
+   * calling `progress()` without any options.
    */
   public get autoSendAnInitialProvisionalResponse(): boolean {
-    return this.rel100 === "required" ? false : true;
+    return this.rel100 !== "required" && this.userAgent.configuration.sendInitialProvisionalResponse;
   }
 
   /**

--- a/src/api/user-agent-options.ts
+++ b/src/api/user-agent-options.ts
@@ -272,6 +272,13 @@ export interface UserAgentOptions {
    * A random hostname in the .invalid domain.
    */
   viaHost?: string;
+
+  /**
+   * If true, a first provisional response after the 100 Trying will be sent automatically if UAC does not
+   * require reliable provisional responses.
+   * @defaultValue `true`
+   */
+  sendInitialProvisionalResponse?: boolean;
 }
 
 /**

--- a/src/api/user-agent.ts
+++ b/src/api/user-agent.ts
@@ -284,7 +284,8 @@ export class UserAgent {
       transportOptions: {},
       uri: new URI("sip", "anonymous", "anonymous.invalid"),
       userAgentString: "SIP.js/" + LIBRARY_VERSION,
-      viaHost: ""
+      viaHost: "",
+      sendInitialProvisionalResponse: true
     };
   }
 


### PR DESCRIPTION
Resolves issue https://github.com/onsip/SIP.js/issues/865.

Adds a configuration parameter to allow turning off automatically sending provisional responses. Defaults to current behaviour.