### PR TITLE
Restore prototype chain in exception when available

### DIFF
--- a/src/core/exceptions/exception.ts
+++ b/src/core/exceptions/exception.ts
@@ -6,6 +6,9 @@
 export abstract class Exception extends Error {
   protected constructor(message?: string) {
     super(message); // 'Error' breaks prototype chain here
-    Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain
+
+    if (new.target) {
+      Object.setPrototypeOf(this, new.target.prototype); // restore prototype chain
+    }
   }
 }


### PR DESCRIPTION
Sometimes when using sip.js on Android we've got this error :
```
{"message":"undefined is not an object (evaluating 'new.target.prototype')","className":"sip.transaction.nict"}

# Stack:
construct@http://localhost:8081/index.android.bundle?platform=android&dev=true&minify=false:104304:28
Wrapper@http://localhost:8081/index.android.bundle?platform=android&dev=true&minify=false:104259:25
Exception@http://localhost:8081/index.android.bundle?platform=android&dev=true&minify=false:148914:107
TransportError@http://localhost:8081/index.android.bundle?platform=android&dev=true&minify=false:148985:111
http://localhost:8081/index.android.bundle?platform=android&dev=true&minify=false:148793:60
```

Line `148793` of `index.android.bundle`:
```
  transportError = new _exceptions.TransportError(error.message);
```

The Exception without `new.target` is a `TransportError` called [here](https://github.com/onsip/SIP.js/blob/bec45980ad920556c4ef2c6260f2ebded7d8f7c7/src/core/transactions/transaction.ts#L126) which correspond to the line `148793` in the stack. 

I don't know why an Error created with `new` doesn't have a `new.target`, so I've added a check.
