### PR TITLE
Add earlyMedia support to SimpleUser object

### DIFF
--- a/src/platform/web/simple-user/simple-user.ts
+++ b/src/platform/web/simple-user/simple-user.ts
@@ -1011,10 +1011,12 @@ export class SimpleUser {
       }
       mediaElement.srcObject = localStream;
       mediaElement.volume = 0;
-      mediaElement.play().catch((error: Error) => {
-        this.logger.error(`[${this.id}] Failed to play local media`);
-        this.logger.error(error.message);
-      });
+      mediaElement.onloadedmetadata= function() {
+        mediaElement.play().catch((error: Error) => {
+          this.logger.error(`[${this.id}] Failed to play local media`);
+          this.logger.error(error.message);
+        });
+      }
     }
   }
 
@@ -1033,7 +1035,7 @@ export class SimpleUser {
       }
       mediaElement.autoplay = true; // Safari hack, because you cannot call .play() from a non user action
       mediaElement.srcObject = remoteStream;
-      if (!this.session.earlyMedia) {
+      mediaElement.onloadedmetadata= function() {
         mediaElement.play().catch((error: Error) => {
           this.logger.error(`[${this.id}] Failed to play remote media`);
           this.logger.error(error.message);

--- a/src/platform/web/simple-user/simple-user.ts
+++ b/src/platform/web/simple-user/simple-user.ts
@@ -768,16 +768,10 @@ export class SimpleUser {
         case SessionState.Initial:
           break;
         case SessionState.Establishing:
-          if (this.session.earlyMedia) {
-            this.setupLocalMedia();
-            this.setupRemoteMedia();
-          }
+          this.setupLocalMedia();
+          this.setupRemoteMedia();
           break;
         case SessionState.Established:
-          if (!this.session.earlyMedia) {
-            this.setupLocalMedia();
-            this.setupRemoteMedia();
-          }
           if (this.delegate && this.delegate.onCallAnswered) {
             this.delegate.onCallAnswered();
           }

--- a/src/platform/web/simple-user/simple-user.ts
+++ b/src/platform/web/simple-user/simple-user.ts
@@ -768,10 +768,16 @@ export class SimpleUser {
         case SessionState.Initial:
           break;
         case SessionState.Establishing:
-          this.setupLocalMedia();
-          this.setupRemoteMedia();
+          if (referralInviterOptions && referralInviterOptions.earlyMedia) {
+            this.setupLocalMedia();
+            this.setupRemoteMedia();
+          }
           break;
         case SessionState.Established:
+          if (!referralInviterOptions || !referralInviterOptions.earlyMedia) {
+            this.setupLocalMedia();
+            this.setupRemoteMedia();
+          }
           if (this.delegate && this.delegate.onCallAnswered) {
             this.delegate.onCallAnswered();
           }

--- a/src/platform/web/simple-user/simple-user.ts
+++ b/src/platform/web/simple-user/simple-user.ts
@@ -768,10 +768,16 @@ export class SimpleUser {
         case SessionState.Initial:
           break;
         case SessionState.Establishing:
+          if (this.session.earlyMedia) {
+            this.setupLocalMedia();
+            this.setupRemoteMedia();
+          }        
           break;
         case SessionState.Established:
-          this.setupLocalMedia();
-          this.setupRemoteMedia();
+          if (!this.session.earlyMedia) {
+            this.setupLocalMedia();
+            this.setupRemoteMedia();
+          }
           if (this.delegate && this.delegate.onCallAnswered) {
             this.delegate.onCallAnswered();
           }
@@ -1027,10 +1033,12 @@ export class SimpleUser {
       }
       mediaElement.autoplay = true; // Safari hack, because you cannot call .play() from a non user action
       mediaElement.srcObject = remoteStream;
-      mediaElement.play().catch((error: Error) => {
-        this.logger.error(`[${this.id}] Failed to play remote media`);
-        this.logger.error(error.message);
-      });
+      if (!this.session.earlyMedia) {
+        mediaElement.play().catch((error: Error) => {
+          this.logger.error(`[${this.id}] Failed to play remote media`);
+          this.logger.error(error.message);
+        });
+      }
       remoteStream.onaddtrack = (): void => {
         this.logger.log(`[${this.id}] Remote media onaddtrack`);
         mediaElement.load(); // Safari hack, as it doesn't work otheriwse

--- a/src/platform/web/simple-user/simple-user.ts
+++ b/src/platform/web/simple-user/simple-user.ts
@@ -771,7 +771,7 @@ export class SimpleUser {
           if (this.session.earlyMedia) {
             this.setupLocalMedia();
             this.setupRemoteMedia();
-          }        
+          }
           break;
         case SessionState.Established:
           if (!this.session.earlyMedia) {
@@ -1011,12 +1011,12 @@ export class SimpleUser {
       }
       mediaElement.srcObject = localStream;
       mediaElement.volume = 0;
-      mediaElement.onloadedmetadata= function() {
+      mediaElement.addEventListener("onloadedmetadata", () => {
         mediaElement.play().catch((error: Error) => {
           this.logger.error(`[${this.id}] Failed to play local media`);
           this.logger.error(error.message);
         });
-      }
+      });
     }
   }
 
@@ -1035,12 +1035,12 @@ export class SimpleUser {
       }
       mediaElement.autoplay = true; // Safari hack, because you cannot call .play() from a non user action
       mediaElement.srcObject = remoteStream;
-      mediaElement.onloadedmetadata= function() {
+      mediaElement.addEventListener("onloadedmetadata", () => {
         mediaElement.play().catch((error: Error) => {
           this.logger.error(`[${this.id}] Failed to play remote media`);
           this.logger.error(error.message);
         });
-      }
+      });
       remoteStream.onaddtrack = (): void => {
         this.logger.log(`[${this.id}] Remote media onaddtrack`);
         mediaElement.load(); // Safari hack, as it doesn't work otheriwse


### PR DESCRIPTION
Set earlyMedia parameter and setup remote and local media if apply into Established SessionState.

		this.m_userAgent.call(`sip:${number}@${this.rtmpServer}`, {
			extraHeaders : [
				...this.m_defaultHeaders
			],
			earlyMedia : true
		})

I need to condition the remote media play because when closing the session it generated an error:
The play () request was interrupted by a new load request.

I did not test video but audio works correctly in the different scenarios.
