### PR TITLE
Support for ephemeral credentials

### DIFF
--- a/src/api/user-agent-options.ts
+++ b/src/api/user-agent-options.ts
@@ -48,7 +48,7 @@ export interface UserAgentOptions {
    * Authorization password.
    * @defaultValue `""`
    */
-  authorizationPassword?: string;
+  authorizationPassword?: string | Function;
 
   /**
    * Authorization username.

--- a/src/core/messages/digest-authentication.ts
+++ b/src/core/messages/digest-authentication.ts
@@ -19,7 +19,7 @@ export class DigestAuthentication {
   private logger: Logger;
   private ha1: string | undefined;
   private username: string | undefined;
-  private password: string | undefined;
+  private password: string | Function | undefined;
   private cnonce: string | undefined;
   private nc: number;
   private ncHex: string;
@@ -42,7 +42,7 @@ export class DigestAuthentication {
     loggerFactory: LoggerFactory,
     ha1: string | undefined,
     username: string | undefined,
-    password: string | undefined
+    password: string | Function | undefined
   ) {
     this.logger = loggerFactory.getLogger("sipjs.digestauthentication");
     this.username = username;
@@ -167,7 +167,11 @@ export class DigestAuthentication {
     // HA1 = MD5(A1) = MD5(username:realm:password)
     ha1 = this.ha1;
     if (ha1 === "" || ha1 === undefined) {
-      ha1 = MD5(this.username + ":" + this.realm + ":" + this.password);
+      if (typeof this.password === "function") {
+        ha1 = MD5(this.username + ":" + this.realm + ":" + this.password());
+      } else {
+        ha1 = MD5(this.username + ":" + this.realm + ":" + this.password);
+      }
     }
 
     if (this.qop === "auth") {


### PR DESCRIPTION
Currently, SIP.js uses the provided credentials to authenticate during the entire session. However, if we want to have ephemeral credentials, we need a way to rotate these credentials during the same session to perform reREGISTER operations.

The goal of this pull request is to improve SIP.js in order to provide a way to obtain credentials in a more dynamic way, i.e. allowing to provide a function that will return the appropriate credentials whenever the (re)authentication is required.