### PR TITLE
fix REGISTER GRUU contact

### DIFF
--- a/src/api/registerer.ts
+++ b/src/api/registerer.ts
@@ -664,7 +664,7 @@ export class Registerer {
    * Generate Contact Header
    */
   private generateContactHeader(expires: number): string {
-    let contact = this.userAgent.contact.toString();
+    let contact = this.userAgent.contact.toString({ register: true });
     if (this.options.regId && this.options.instanceId) {
       contact += ";reg-id=" + this.options.regId;
       contact += ';+sip.instance="<urn:uuid:' + this.options.instanceId + '>"';

--- a/src/api/user-agent.ts
+++ b/src/api/user-agent.ts
@@ -601,14 +601,17 @@ export class UserAgent {
       pubGruu: undefined,
       tempGruu: undefined,
       uri: new URI("sip", contactName, this.options.viaHost, undefined, contactParams),
-      toString: (contactToStringOptions: { anonymous?: boolean; outbound?: boolean } = {}): string => {
+      toString: (contactToStringOptions: { anonymous?: boolean; outbound?: boolean; register?: boolean } = {}): string => {
         const anonymous = contactToStringOptions.anonymous || false;
         const outbound = contactToStringOptions.outbound || false;
+        const register = contactToStringOptions.register || false;
         let contactString = "<";
         if (anonymous) {
           contactString +=
             this.contact.tempGruu ||
             `sip:anonymous@anonymous.invalid;transport=${contactParams.transport ? contactParams.transport : "ws"}`;
+        } else if (register) {
+          contactString += this.contact.uri;
         } else {
           contactString += this.contact.pubGruu || this.contact.uri;
         }

--- a/src/core/user-agent-core/user-agent-core-configuration.ts
+++ b/src/core/user-agent-core/user-agent-core-configuration.ts
@@ -15,7 +15,7 @@ export interface Contact {
   pubGruu: URI | undefined;
   tempGruu: URI | undefined;
   uri: URI;
-  toString: (options?: { anonymous?: boolean; outbound?: boolean }) => string;
+  toString: (options?: { anonymous?: boolean; outbound?: boolean; register?: boolean }) => string;
 }
 
 /**


### PR DESCRIPTION
REGISTER request must not use GRUU as contact value. (it breaks RURI and its parameters)

According [rfc5627](https://datatracker.ietf.org/doc/html/rfc5627)

> [3.3](https://datatracker.ietf.org/doc/html/rfc5627#section-3.3).  Using a GRUU
> 
>    Once a user agent obtains GRUUs from the registrar, it uses them in
>    several ways.  First, it uses them as the contents of the Contact
>    header field in non-REGISTER requests and responses that it emits
>    (for example, an INVITE request and 200 OK response).  According to
>    [RFC 3261](https://datatracker.ietf.org/doc/html/rfc3261) [[1](https://datatracker.ietf.org/doc/html/rfc5627#ref-1)], the Contact header field is supposed to contain a URI
>    that routes to that user agent.  Prior to this specification, there
>    hasn't been a way to really meet that requirement.  The user agent
>    would use one of its temporary GRUUs for anonymous calls, and use its
>    public GRUU otherwise.
> 
>    Second, the UA can use the GRUU in any other place it needs to use a
>    URI that resolves to itself, such as a webpage.