### PR TITLE
session.ts: Send Reason header with BYE on re-INVITE failure.

### DIFF
--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -991,7 +991,7 @@ export abstract class Session {
               }
               const extraHeadersBye: Array<string> = [];
               extraHeadersBye.push("Reason: " + this.getReasonHeaderValue(500, "Internal Server Error"));
-              this.dialog.bye(undefined, { extraHeaders });
+              this.dialog.bye(undefined, { extraHeaders: extraHeadersBye });
               this.stateTransition(SessionState.Terminated);
             }
             if (this.delegate && this.delegate.onInvite) {


### PR DESCRIPTION
This is currently using the wrong array of headers.