### PR TITLE
session-manager.ts: Optionally send DTMF via SDH.

### DIFF
--- a/src/platform/web/session-manager/session-manager-options.ts
+++ b/src/platform/web/session-manager/session-manager-options.ts
@@ -25,6 +25,9 @@ export interface SessionManagerMedia {
 
   /** Local HTML media elements. */
   remote?: SessionManagerMediaRemote | ((session: Session) => SessionManagerMediaRemote);
+
+  /** Whether to use the SessionDescriptionHandler to send DTMF */
+  sendDtmfUsingSessionDescriptionHandler?: boolean;
 }
 
 /**


### PR DESCRIPTION
Obviously the setting name is bad and probably in the wrong place but I wanted a baseline to get a conversation going.

I want to be able to send DTMF via RTP with `SimpleUser` (I really don't want to roll my own version of `SimpleUser` just for this). Thoughts on if this is something you will entertain and, if so, what would you accept in terms of configuration flag/location?