### PR TITLE
Support customizing the transport protocol used for Via headers

### DIFF
--- a/src/platform/web/transport/transport-options.ts
+++ b/src/platform/web/transport/transport-options.ts
@@ -31,4 +31,10 @@ export interface TransportOptions {
    * @defaultValue `true`
    */
   traceSip?: boolean;
+
+  /**
+   * The transport protocol to use in Via header declarations.
+   * If not specified, will be inferred from the server URL.
+   */
+  headerProtocol?: string;
 }

--- a/src/platform/web/transport/transport.ts
+++ b/src/platform/web/transport/transport.ts
@@ -104,7 +104,7 @@ export class Transport implements TransportDefinition {
 
     // Use the explicit header protocol if defined, but fall back to the
     // server's indicated scheme
-    if (this.configuration.headerProtocol !== "") {
+    if (typeof this.configuration.headerProtocol === "string" && this.configuration.headerProtocol !== "") {
       this._protocol = this.configuration.headerProtocol.toUpperCase();
     } else {
       this._protocol = parsed.scheme.toUpperCase();

--- a/src/platform/web/transport/transport.ts
+++ b/src/platform/web/transport/transport.ts
@@ -16,7 +16,8 @@ export class Transport implements TransportDefinition {
     connectionTimeout: 5,
     keepAliveInterval: 0,
     keepAliveDebounce: 10,
-    traceSip: true
+    traceSip: true,
+    headerProtocol: ""
   };
 
   public onConnect: (() => void) | undefined;
@@ -100,7 +101,14 @@ export class Transport implements TransportDefinition {
       this.logger.error(`Invalid scheme in WebSocket Server URL "${url}"`);
       throw new Error("Invalid scheme in WebSocket Server URL");
     }
-    this._protocol = parsed.scheme.toUpperCase();
+
+    // Use the explicit header protocol if defined, but fall back to the
+    // server's indicated scheme
+    if (this.configuration.headerProtocol !== "") {
+      this._protocol = this.configuration.headerProtocol.toUpperCase();
+    } else {
+      this._protocol = parsed.scheme.toUpperCase();
+    }
   }
 
   public dispose(): Promise<void> {

--- a/test/spec/platform/web/transport.spec.ts
+++ b/test/spec/platform/web/transport.spec.ts
@@ -64,6 +64,21 @@ describe("Web Transport", () => {
 
     // The transport should now be in the Disconnected state, so traverse the FSM.
     traverseTransportStateMachine();
+
+    describe("supports customized header protocols", () => {
+      // constructTransport normally validates that the protocol is WSS
+      // given that the server URL is wss://...
+      const headerProtocol = "ws";
+      const customizedTransport = new Transport(logger, {
+        connectionTimeout,
+        server,
+        headerProtocol
+      });
+
+      it("protocol MUST be WS", () => {
+        expect(customizedTransport.protocol).toBe(headerProtocol.toUpperCase());
+      });
+    });
   });
 
   function initServer(): void {


### PR DESCRIPTION
This allows for transport protocols that are not based solely on `Transport.server`'s URL scheme.

This provides a path for eliminating the [deprecated `UserAgentOptions.hackViaTcp` configuration option](https://github.com/onsip/SIP.js/blob/b26885ce24a5788dd3f3db45f726c93e6b7b3763/docs/api/sip.js.useragentoptions.hackviatcp.md), as the transport options can now have `{ headerProtocol: "TCP" }` in its place.

This change is also useful when working with SIP endpoints that are behind a load balancer with SSL termination at the balancer. In that case, the transport protocol between the browser and the load balancer would use the SIPS/WSS/TLS protocol, but I believe [the transport protocol indicated in the Via header](https://www.rfc-editor.org/rfc/rfc3261#section-20.42) would need to be SIP/WS/TCP when it reaches the SIP endpoints.

## Potential Alternative

Instead of impacting `Transport.protocol`, I considered adding an alternate `Transport.headerProtocol` property that would be referenced in `setViaHeader` calls.

However, the core `Transport.protocol` property states that it is formatted "as defined for the Via header sent-protocol transport", and `Transport.protocol` is currently only referenced for the purposes of `setViaHeader` calls, so I felt this would be redundant.