### PR TITLE
Support for ephemeral credentials

### DIFF
--- a/src/api/user-agent-options.ts
+++ b/src/api/user-agent-options.ts
@@ -49,13 +49,13 @@ export interface UserAgentOptions {
    * Authorization password.
    * @defaultValue `""`
    */
-  authorizationPassword?: string;
+  authorizationPassword?: string | (() => string);
 
   /**
    * Authorization username.
    * @defaultValue `""`
    */
-  authorizationUsername?: string;
+  authorizationUsername?: string | (() => string);
 
   /**
    * The user portion of user agent's contact URI.


### PR DESCRIPTION
Currently, SIP.js uses the provided credentials to authenticate during the entire session. However, if we want to have ephemeral credentials, we need a way to rotate these credentials during the same session to perform reREGISTER operations.

The goal of this pull request is to improve SIP.js in order to provide a way to obtain credentials in a more dynamic way, i.e. allowing to provide a function that will return the appropriate credentials whenever the (re)authentication is required.

ℹ️ This change was already submitted and approved in the PR [#941](https://github.com/onsip/SIP.js/pull/941) but it was never released. I believe it was somehow lost when the default development branch was moved from `master` to `main` .