### PR TITLE
Parse scope idetifier on IPv6 addresses

### DIFF
--- a/src/grammar/pegjs/src/grammar.pegjs
+++ b/src/grammar/pegjs/src/grammar.pegjs
@@ -177,8 +177,9 @@ IPv6address     = ( h16 ":" h16 ":" h16 ":" h16 ":" h16 ":" h16 ":" ls32
 
 h16             = HEXDIG HEXDIG? HEXDIG? HEXDIG?
 
-ls32            = ( h16 ":" h16 ) / IPv4address
+ls32            = ( h16 ":" h16 (scope_identifier)? ) / IPv4address
 
+scope_identifier  = "%" (alphanum)+
 
 IPv4address     = dec_octet "." dec_octet "." dec_octet "." dec_octet {
                     options = options || { data: {}};


### PR DESCRIPTION
During development we required IPv6 with scope identfiiers in the SIP Via and Contact Header. 

New the SIP Via header in the format: 
- Via: ...;received:fe80::XXXX:XXXX:XXXX:XXXX%eth0;....
And the SIP Contact header:
- Contact: <sip:[fe80::XXXX:XXXX:XXXX:XXXX%eth0]:Port;...>
can be parsed.

Threre is no additional Field in the NameAddrHeader -> URI. The whole IPv6 address is still stored in the host property.