### PR TITLE
Prevent SIP.js stack to crash app on re-register when there is already an outstanding REGISTER request

### DIFF
--- a/src/api/registerer.ts
+++ b/src/api/registerer.ts
@@ -678,6 +678,10 @@ export class Registerer {
     // For that, calculate the delay as a percentage of the expiration time
     this.registrationTimer = setTimeout(() => {
       this.registrationTimer = undefined;
+      if (this.waiting) {
+        this.logger.warn("Outstanding REGISTER request already in progress, skipping re-registration");
+        return;
+      }
       this.register();
     }, (this.refreshFrequency / 100) * expires * 1000);
 


### PR DESCRIPTION
In our code base we took the approach of using the full API framework instead of using the SimpleUser class.

We instantiate the `Registerer` to register our user agent.

In some cases we are getting this uncaught error by the SIP.js stack causing our nodejs process to stop.

```
REGISTER request already in progress, waiting for final response
```

From my analysis this can happen if we attempt to call the register function, and in parallel the [re-register function](https://github.com/Escaux/SIP.js/blob/main/src/api/registerer.ts#L679-L682) is called on timeout.

I have opted to check if the waiting flag is set instead of blindly catching the exception, but I am open to other suggestions. 

